### PR TITLE
WIP: Configure feedstocks for self-updates via CI

### DIFF
--- a/.ci_scripts/push_changes
+++ b/.ci_scripts/push_changes
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ -n "$GH_TOKEN" ]; then
+    # Only build the docs for commits on master.
+    if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
+        git commit -am "Updated feedstocks. [ci skip]" | true
+        git remote add pushable https://${GH_TOKEN}@github.com/conda-forge/conda-forge.github.io.git/ > /dev/null
+        git push pushable new_site_content:master 2> /dev/null
+    fi
+fi

--- a/.ci_scripts/refresh_repo
+++ b/.ci_scripts/refresh_repo
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# This script is to be run in a TravisCI context.
+
+set -e
+
+if [ -n "$GH_TOKEN" ]; then
+    # Make sure we are on the latest commit on `master` if we are planning to deploy the change.
+    if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
+        git checkout master
+    fi
+fi

--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# This script is to be run in a TravisCI context.
+
+set -e
+
+if [ -n "$GH_TOKEN" ]; then
+    git checkout -b new_site_content
+    # Generate html requires a GitHub token in order to query the available feedstocks.
+    conda execute scripts/generate_html.py
+    git diff
+fi

--- a/.ci_scripts/update_feedstocks_repo
+++ b/.ci_scripts/update_feedstocks_repo
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Expected to be run in a TravisCI context.
+
+set -e
+
+if [ -n "$GH_TOKEN" ]; then
+    conda execute -v ./scripts/update_feedstocks_submodules.py .
+fi

--- a/.ci_scripts/update_teams
+++ b/.ci_scripts/update_teams
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Expected to be run in a TravisCI context.
+
+set -e
+
+if [ -n "$GH_TOKEN" ]; then
+    conda execute -v ./scripts/update_teams.py ./feedstocks
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+# The language in this case has no bearing - we are going to be making use of conda for a
+# python distribution for the scientific python stack.
+language: generic
+
+sudo: false
+
+env:
+    global:
+       - CONDA_INSTALL_LOCN="${HOME}/conda"
+
+       # Adds a GH_TOKEN (conda-forge-admin's conda-forge.github.io token)
+       - secure: __FIX_ME__
+
+install:
+    - mkdir -p ${HOME}/cache/pkgs
+    - "[ ! -f ${HOME}/cache/miniconda.sh ] && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${HOME}/cache/miniconda.sh || :"
+    - bash ${HOME}/cache/miniconda.sh -b -p ${CONDA_INSTALL_LOCN} && export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
+
+    # Re-use the packages in the cache, and download any new ones into that location.
+    - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
+
+    - git config --global user.name "Travis-CI on github.com/conda-forge/conda-forge.github.io"
+    - git config --global user.email pelson.pub+conda-forge@gmail.com
+    - mkdir -p ~/.conda-smithy && echo $GH_TOKEN > ~/.conda-smithy/github.token
+
+    # Now do the things we need to do to install it.
+    - conda install conda-execute --yes --quiet -c conda-forge
+
+script:
+    - echo "Refresh repo";
+      source ./.ci_scripts/refresh_repo
+
+    - echo "Updating docs";
+      source ./.ci_scripts/update_docs
+
+    - echo "Updating feedstock repo";
+      source ./.ci_scripts/update_feedstocks_repo
+
+    - echo "Updating the teams";
+      source ./.ci_scripts/update_teams
+
+    - echo "Pushing all changes";
+      source ./.ci_scripts/push_changes
+
+# We store the files that are downloaded from continuum.io, but not the environments that are created.
+cache:
+    directories:
+      - $HOME/cache
+before_cache:
+  # Remove all untarred directories.
+  - find $CONDA_INSTALL_LOCN/pkgs/ -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,6162 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>conda-forge feedstocks | community driven packaging for conda</title>
+
+    <!-- Bootstrap Core CSS -->
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="css/theme.css" rel="stylesheet">
+
+    <!-- Custom Fonts -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link hrefs="http://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+        <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+</head>
+
+<body id="page-top" data-spy="scroll" data-target=".navbar-fixed-top">
+
+    <!-- Navigation -->
+    <nav class="navbar navbar-custom navbar-fixed-top" role="navigation">
+        <div class="container semi-black-alpha" role="navigation">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
+                    <i class="fa fa-bars"></i>
+                </button>
+                <a class="navbar-brand page-scroll" href="./#page-top">
+                    <i><img src="img/anvil_white.png" alt="An anvil" style="height: 1em;"></i>  <span class="light">conda-forge</span>
+                </a>
+            </div>
+
+            <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
+                <ul class="nav navbar-nav">
+                    <li>
+                        <a class="page-scroll" href="./#about">About</a>
+                    </li>
+                    <li>
+                        <a class="page-scroll" href="./#contribute">Contribute</a>
+                    </li>
+                    <li class="active">
+                        <a href="feedstocks.html">Packages</a>
+                    </li>
+                    <li>
+                        <a href="./status">Status</a>
+                    </li>
+
+                </ul>
+            </div>
+            <!-- /.navbar-collapse -->
+        </div>
+        <!-- /.container -->
+    </nav>
+
+    <!-- About Section -->
+    <section id="feedstocks" class="container content-section">
+        <div class="row">
+            <div class="col-lg-8 col-lg-offset-2">
+                <h2 class="text-center">Feedstocks on conda-forge</h2>
+                <ul class="list-group">
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/addict-feedstock">
+                            addict
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/affine-feedstock">
+                            affine
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/alabaster-feedstock">
+                            alabaster
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/alembic-feedstock">
+                            alembic
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/altair-feedstock">
+                            altair
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/amqp-feedstock">
+                            amqp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/anaconda-client-feedstock">
+                            anaconda-client
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/anaconda-verify-feedstock">
+                            anaconda-verify
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/aniso8601-feedstock">
+                            aniso8601
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/antispoofing.utils-feedstock">
+                            antispoofing.utils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/antlr-feedstock">
+                            antlr
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/anyjson-feedstock">
+                            anyjson
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/anypytools-feedstock">
+                            anypytools
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/apache-libcloud-feedstock">
+                            apache-libcloud
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/appdirs-feedstock">
+                            appdirs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/apptools-feedstock">
+                            apptools
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/apscheduler-feedstock">
+                            apscheduler
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/argparse-feedstock">
+                            argparse
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/args-feedstock">
+                            args
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/arm_pyart-feedstock">
+                            arm_pyart
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/arrow-feedstock">
+                            arrow
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/artview-feedstock">
+                            artview
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/asciitree-feedstock">
+                            asciitree
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/assetid-feedstock">
+                            assetid
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/astroid-feedstock">
+                            astroid
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/asyncssh-feedstock">
+                            asyncssh
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/atom-feedstock">
+                            atom
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/attrdict-feedstock">
+                            attrdict
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/audioread-feedstock">
+                            audioread
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/auditwheel-feedstock">
+                            auditwheel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/autoconf-feedstock">
+                            autoconf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/autograd-feedstock">
+                            autograd
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/automake-feedstock">
+                            automake
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/autopep8-feedstock">
+                            autopep8
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/avro-feedstock">
+                            avro
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/awesome-slugify-feedstock">
+                            awesome-slugify
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/awscli-feedstock">
+                            awscli
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-common-feedstock">
+                            azure-common
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-feedstock">
+                            azure
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-mgmt-common-feedstock">
+                            azure-mgmt-common
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-mgmt-compute-feedstock">
+                            azure-mgmt-compute
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-mgmt-feedstock">
+                            azure-mgmt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-mgmt-network-feedstock">
+                            azure-mgmt-network
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-mgmt-nspkg-feedstock">
+                            azure-mgmt-nspkg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-mgmt-resource-feedstock">
+                            azure-mgmt-resource
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-mgmt-storage-feedstock">
+                            azure-mgmt-storage
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-nspkg-feedstock">
+                            azure-nspkg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-servicebus-feedstock">
+                            azure-servicebus
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-servicemanagement-legacy-feedstock">
+                            azure-servicemanagement-legacy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/azure-storage-feedstock">
+                            azure-storage
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/babel-feedstock">
+                            babel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/backports.functools_lru_cache-feedstock">
+                            backports.functools_lru_cache
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/backports.shutil_get_terminal_size-feedstock">
+                            backports.shutil_get_terminal_size
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/backports_abc-feedstock">
+                            backports_abc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/basemap-data-hires-feedstock">
+                            basemap-data-hires
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/basemap-feedstock">
+                            basemap
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bc-feedstock">
+                            bc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bdw-gc-feedstock">
+                            bdw-gc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/betamax-feedstock">
+                            betamax
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/betamax-matchers-feedstock">
+                            betamax-matchers
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/biggus-feedstock">
+                            biggus
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/billiard-feedstock">
+                            billiard
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/binaryornot-feedstock">
+                            binaryornot
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/binutils-feedstock">
+                            binutils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bison-feedstock">
+                            bison
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/blas-feedstock">
+                            blas
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/blinker-feedstock">
+                            blinker
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob-feedstock">
+                            bob
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ap-feedstock">
+                            bob.ap
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.bio.base-feedstock">
+                            bob.bio.base
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.bio.face-feedstock">
+                            bob.bio.face
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.bio.gmm-feedstock">
+                            bob.bio.gmm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.bio.spear-feedstock">
+                            bob.bio.spear
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.bio.video-feedstock">
+                            bob.bio.video
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.blitz-feedstock">
+                            bob.blitz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.core-feedstock">
+                            bob.core
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.arface-feedstock">
+                            bob.db.arface
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.atnt-feedstock">
+                            bob.db.atnt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.atvskeystroke-feedstock">
+                            bob.db.atvskeystroke
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.avspoof-feedstock">
+                            bob.db.avspoof
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.banca-feedstock">
+                            bob.db.banca
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.base-feedstock">
+                            bob.db.base
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.biosecure-feedstock">
+                            bob.db.biosecure
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.biosecurid.face-feedstock">
+                            bob.db.biosecurid.face
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.casia_fasd-feedstock">
+                            bob.db.casia_fasd
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.casme2-feedstock">
+                            bob.db.casme2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.caspeal-feedstock">
+                            bob.db.caspeal
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.frgc-feedstock">
+                            bob.db.frgc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.gbu-feedstock">
+                            bob.db.gbu
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.iris-feedstock">
+                            bob.db.iris
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.kboc16-feedstock">
+                            bob.db.kboc16
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.lfw-feedstock">
+                            bob.db.lfw
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.livdet2013-feedstock">
+                            bob.db.livdet2013
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.mnist-feedstock">
+                            bob.db.mnist
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.mobio-feedstock">
+                            bob.db.mobio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.msu_mfsd_mod-feedstock">
+                            bob.db.msu_mfsd_mod
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.multipie-feedstock">
+                            bob.db.multipie
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.nist_sre12-feedstock">
+                            bob.db.nist_sre12
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.replay-feedstock">
+                            bob.db.replay
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.scface-feedstock">
+                            bob.db.scface
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.utfvp-feedstock">
+                            bob.db.utfvp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.verification.filelist-feedstock">
+                            bob.db.verification.filelist
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.verification.utils-feedstock">
+                            bob.db.verification.utils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.voxforge-feedstock">
+                            bob.db.voxforge
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.wine-feedstock">
+                            bob.db.wine
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.xm2vts-feedstock">
+                            bob.db.xm2vts
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.db.youtube-feedstock">
+                            bob.db.youtube
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.extension-feedstock">
+                            bob.extension
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.io.audio-feedstock">
+                            bob.io.audio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.io.base-feedstock">
+                            bob.io.base
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.io.image-feedstock">
+                            bob.io.image
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.io.matlab-feedstock">
+                            bob.io.matlab
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.io.video-feedstock">
+                            bob.io.video
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.base-feedstock">
+                            bob.ip.base
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.color-feedstock">
+                            bob.ip.color
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.draw-feedstock">
+                            bob.ip.draw
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.facedetect-feedstock">
+                            bob.ip.facedetect
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.flandmark-feedstock">
+                            bob.ip.flandmark
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.gabor-feedstock">
+                            bob.ip.gabor
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.optflow.hornschunck-feedstock">
+                            bob.ip.optflow.hornschunck
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.ip.optflow.liu-feedstock">
+                            bob.ip.optflow.liu
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.learn.activation-feedstock">
+                            bob.learn.activation
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.learn.boosting-feedstock">
+                            bob.learn.boosting
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.learn.em-feedstock">
+                            bob.learn.em
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.learn.libsvm-feedstock">
+                            bob.learn.libsvm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.learn.linear-feedstock">
+                            bob.learn.linear
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.learn.mlp-feedstock">
+                            bob.learn.mlp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.math-feedstock">
+                            bob.math
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.measure-feedstock">
+                            bob.measure
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bob.sp-feedstock">
+                            bob.sp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/boltons-feedstock">
+                            boltons
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/boost-feedstock">
+                            boost
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/botocore-feedstock">
+                            botocore
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bottleneck-feedstock">
+                            bottleneck
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/bqplot-feedstock">
+                            bqplot
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/branca-feedstock">
+                            branca
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/brewer2mpl-feedstock">
+                            brewer2mpl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/c99-to-c89-feedstock">
+                            c99-to-c89
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ca-certificates-feedstock">
+                            ca-certificates
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/caffe-feedstock">
+                            caffe
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cairo-feedstock">
+                            cairo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cairomm-feedstock">
+                            cairomm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/capnproto-feedstock">
+                            capnproto
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/capturer-feedstock">
+                            capturer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cartopy-feedstock">
+                            cartopy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/category_encoders-feedstock">
+                            category_encoders
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/catimg-feedstock">
+                            catimg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cc-plugin-glider-feedstock">
+                            cc-plugin-glider
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cc-plugin-ncei-feedstock">
+                            cc-plugin-ncei
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cdat-lite-feedstock">
+                            cdat-lite
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cdo-feedstock">
+                            cdo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/celery-feedstock">
+                            celery
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cell_tree2d-feedstock">
+                            cell_tree2d
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/certifi-feedstock">
+                            certifi
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cf_units-feedstock">
+                            cf_units
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cfchecker-feedstock">
+                            cfchecker
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cgal-feedstock">
+                            cgal
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/channelarchiver-feedstock">
+                            channelarchiver
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/chartkick-feedstock">
+                            chartkick
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/check-feedstock">
+                            check
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cherrypy-feedstock">
+                            cherrypy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/circleci-helpers-feedstock">
+                            circleci-helpers
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/circleclient-feedstock">
+                            circleclient
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cis-feedstock">
+                            cis
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ciso-feedstock">
+                            ciso
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ckanapi-feedstock">
+                            ckanapi
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/click-feedstock">
+                            click
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/click-plugins-feedstock">
+                            click-plugins
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cliff-feedstock">
+                            cliff
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/clint-feedstock">
+                            clint
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cloog-feedstock">
+                            cloog
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cloud_sptheme-feedstock">
+                            cloud_sptheme
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cloudpickle-feedstock">
+                            cloudpickle
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/clusterpy-feedstock">
+                            clusterpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/clyent-feedstock">
+                            clyent
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cmake-feedstock">
+                            cmake
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cmd2-feedstock">
+                            cmd2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cmocean-feedstock">
+                            cmocean
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cmt-feedstock">
+                            cmt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/codar2netcdf-feedstock">
+                            codar2netcdf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/coincbc-feedstock">
+                            coincbc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/colorama-feedstock">
+                            colorama
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/coloredlogs-feedstock">
+                            coloredlogs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/colorlog-feedstock">
+                            colorlog
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/compliance-checker-feedstock">
+                            compliance-checker
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-build-all-feedstock">
+                            conda-build-all
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-build-feedstock">
+                            conda-build
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-env-feedstock">
+                            conda-env
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-execute-feedstock">
+                            conda-execute
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-feedstock">
+                            conda
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-forge-build-setup-feedstock">
+                            conda-forge-build-setup
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-smithy-feedstock">
+                            conda-smithy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-testenv-feedstock">
+                            conda-testenv
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/conda-workon-feedstock">
+                            conda-workon
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/configparser-feedstock">
+                            configparser
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/configurable-http-proxy-feedstock">
+                            configurable-http-proxy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/constructor-feedstock">
+                            constructor
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/contextlib2-feedstock">
+                            contextlib2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cookiecutter-feedstock">
+                            cookiecutter
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cotire-feedstock">
+                            cotire
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/coverage-feedstock">
+                            coverage
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/croniter-feedstock">
+                            croniter
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/csa-feedstock">
+                            csa
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cssselect-feedstock">
+                            cssselect
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cssutils-feedstock">
+                            cssutils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ctd-feedstock">
+                            ctd
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cunit-feedstock">
+                            cunit
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/curl-feedstock">
+                            curl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cvxopt-feedstock">
+                            cvxopt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cyavro-feedstock">
+                            cyavro
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cycler-feedstock">
+                            cycler
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cyordereddict-feedstock">
+                            cyordereddict
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cython-feedstock">
+                            cython
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cythongsl-feedstock">
+                            cythongsl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/cytoolz-feedstock">
+                            cytoolz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dask-feedstock">
+                            dask
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dateutils-feedstock">
+                            dateutils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dcmstack-feedstock">
+                            dcmstack
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/deap-feedstock">
+                            deap
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/debtcollector-feedstock">
+                            debtcollector
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dec2-feedstock">
+                            dec2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/depfinder-feedstock">
+                            depfinder
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/descartes-feedstock">
+                            descartes
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dill-feedstock">
+                            dill
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dipy-feedstock">
+                            dipy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/diskcache-feedstock">
+                            diskcache
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/distributed-feedstock">
+                            distributed
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dj-static-feedstock">
+                            dj-static
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-autoslug-feedstock">
+                            django-autoslug
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-celery-feedstock">
+                            django-celery
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-debug-toolbar-feedstock">
+                            django-debug-toolbar
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-enumfields-feedstock">
+                            django-enumfields
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-extensions-feedstock">
+                            django-extensions
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-feedstock">
+                            django
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-grappelli-feedstock">
+                            django-grappelli
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-nested-inline-feedstock">
+                            django-nested-inline
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-redis-cache-feedstock">
+                            django-redis-cache
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-rest-hooks-feedstock">
+                            django-rest-hooks
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-taggit-feedstock">
+                            django-taggit
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django-typed-models-feedstock">
+                            django-typed-models
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/django_polymorphic-feedstock">
+                            django_polymorphic
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/djangorestframework-feedstock">
+                            djangorestframework
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/docker-py-feedstock">
+                            docker-py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/docopt-feedstock">
+                            docopt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/docstring-coverage-feedstock">
+                            docstring-coverage
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/doct-feedstock">
+                            doct
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/doctr-feedstock">
+                            doctr
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/docutils-feedstock">
+                            docutils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dodgy-feedstock">
+                            dodgy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dxchange-feedstock">
+                            dxchange
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/dxfile-feedstock">
+                            dxfile
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/eccodes-feedstock">
+                            eccodes
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ecmwf-api-client-feedstock">
+                            ecmwf-api-client
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ecmwf_grib-feedstock">
+                            ecmwf_grib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/edffile-feedstock">
+                            edffile
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/effect-feedstock">
+                            effect
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/eigen-feedstock">
+                            eigen
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/elasticsearch-dsl-feedstock">
+                            elasticsearch-dsl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/elasticsearch-feedstock">
+                            elasticsearch
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/emcee-feedstock">
+                            emcee
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/emperor-feedstock">
+                            emperor
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/entrypoints-feedstock">
+                            entrypoints
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/enum34-feedstock">
+                            enum34
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/envisage-feedstock">
+                            envisage
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/eofs-feedstock">
+                            eofs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/epic2cf-feedstock">
+                            epic2cf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/erlang-feedstock">
+                            erlang
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/esmf-feedstock">
+                            esmf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/esmpy-feedstock">
+                            esmpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/event-model-feedstock">
+                            event-model
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/eventlet-feedstock">
+                            eventlet
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/exec-wrappers-feedstock">
+                            exec-wrappers
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/expat-feedstock">
+                            expat
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/extras-feedstock">
+                            extras
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/f90wrap-feedstock">
+                            f90wrap
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fabio-feedstock">
+                            fabio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fake-factory-feedstock">
+                            fake-factory
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fastavro-feedstock">
+                            fastavro
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fasteners-feedstock">
+                            fasteners
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/feather-format-feedstock">
+                            feather-format
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/feedgenerator-feedstock">
+                            feedgenerator
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/feedstockrot-feedstock">
+                            feedstockrot
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ferret_datasets-feedstock">
+                            ferret_datasets
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ffmpeg-feedstock">
+                            ffmpeg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fftw-feedstock">
+                            fftw
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ffx-feedstock">
+                            ffx
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/filechunkio-feedstock">
+                            filechunkio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/filelock-feedstock">
+                            filelock
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/findspark-feedstock">
+                            findspark
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fiona-feedstock">
+                            fiona
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flake8-feedstock">
+                            flake8
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flann-feedstock">
+                            flann
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-babel-feedstock">
+                            flask-babel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-babelex-feedstock">
+                            flask-babelex
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-bcrypt-feedstock">
+                            flask-bcrypt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-cache-feedstock">
+                            flask-cache
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-login-feedstock">
+                            flask-login
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-oauthlib-feedstock">
+                            flask-oauthlib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-sqlalchemy-feedstock">
+                            flask-sqlalchemy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flask-wtf-feedstock">
+                            flask-wtf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flatbuffers-feedstock">
+                            flatbuffers
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flex-feedstock">
+                            flex
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flexx-feedstock">
+                            flexx
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flo-feedstock">
+                            flo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flopy-feedstock">
+                            flopy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/flower-feedstock">
+                            flower
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/folium-feedstock">
+                            folium
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fontconfig-feedstock">
+                            fontconfig
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fortran-magic-feedstock">
+                            fortran-magic
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/freeglut-feedstock">
+                            freeglut
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/freeimage-feedstock">
+                            freeimage
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/freetype-feedstock">
+                            freetype
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/freexl-feedstock">
+                            freexl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/freezegun-feedstock">
+                            freezegun
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/frosted-feedstock">
+                            frosted
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/funcsigs-feedstock">
+                            funcsigs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/functools32-feedstock">
+                            functools32
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/future-feedstock">
+                            future
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/fuzzywuzzy-feedstock">
+                            fuzzywuzzy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/g2clib-feedstock">
+                            g2clib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gdal-feedstock">
+                            gdal
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gdcm-feedstock">
+                            gdcm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/genshi-feedstock">
+                            genshi
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/geoalchemy2-feedstock">
+                            geoalchemy2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/geojson-feedstock">
+                            geojson
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/geojsonio-feedstock">
+                            geojsonio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/geolinks-feedstock">
+                            geolinks
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/geopandas-feedstock">
+                            geopandas
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/geopy-feedstock">
+                            geopy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/geos-feedstock">
+                            geos
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gettext-feedstock">
+                            gettext
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gflags-feedstock">
+                            gflags
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ggplot-feedstock">
+                            ggplot
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ghp-import-feedstock">
+                            ghp-import
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/giflib-feedstock">
+                            giflib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/girder-client-feedstock">
+                            girder-client
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/girder-feedstock">
+                            girder
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/git-feedstock">
+                            git
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gitdb-feedstock">
+                            gitdb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/github3.py-feedstock">
+                            github3.py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gitpython-feedstock">
+                            gitpython
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glances-feedstock">
+                            glances
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glib-feedstock">
+                            glib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glibmm-feedstock">
+                            glibmm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glog-feedstock">
+                            glog
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glpk-feedstock">
+                            glpk
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glue-vispy-viewers-feedstock">
+                            glue-vispy-viewers
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glueviz-feedstock">
+                            glueviz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/glymur-feedstock">
+                            glymur
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gmp-feedstock">
+                            gmp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gmpy2-feedstock">
+                            gmpy2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gnureadline-feedstock">
+                            gnureadline
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/google-api-python-client-feedstock">
+                            google-api-python-client
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/google-apputils-feedstock">
+                            google-apputils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gperf-feedstock">
+                            gperf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gpxpy-feedstock">
+                            gpxpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/graphviz-feedstock">
+                            graphviz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gridfill-feedstock">
+                            gridfill
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gridgen-feedstock">
+                            gridgen
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gridgeo-feedstock">
+                            gridgeo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gridutils-feedstock">
+                            gridutils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gsl-feedstock">
+                            gsl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gsw-feedstock">
+                            gsw
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/gunicorn-feedstock">
+                            gunicorn
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/h5netcdf-feedstock">
+                            h5netcdf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/h5py-feedstock">
+                            h5py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hachoir-core-feedstock">
+                            hachoir-core
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hachoir-metadata-feedstock">
+                            hachoir-metadata
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hachoir-parser-feedstock">
+                            hachoir-parser
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/happybase-feedstock">
+                            happybase
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/harfbuzz-feedstock">
+                            harfbuzz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/haversine-feedstock">
+                            haversine
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hdbscan-feedstock">
+                            hdbscan
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hdf4-feedstock">
+                            hdf4
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hdf5-feedstock">
+                            hdf5
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hdfeos2-feedstock">
+                            hdfeos2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hdfeos5-feedstock">
+                            hdfeos5
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hdfs3-feedstock">
+                            hdfs3
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/healpy-feedstock">
+                            healpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/helper-feedstock">
+                            helper
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hiredis-feedstock">
+                            hiredis
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/historydict-feedstock">
+                            historydict
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hive-thrift-py-feedstock">
+                            hive-thrift-py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hiveplot-feedstock">
+                            hiveplot
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hmat-oss-feedstock">
+                            hmat-oss
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/holoviews-feedstock">
+                            holoviews
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/htmlmin-feedstock">
+                            htmlmin
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/httplib2-feedstock">
+                            httplib2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/httpretty-feedstock">
+                            httpretty
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/humanfriendly-feedstock">
+                            humanfriendly
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/humanize-feedstock">
+                            humanize
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hyperspy-feedstock">
+                            hyperspy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/hypothesis-feedstock">
+                            hypothesis
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ibis-framework-feedstock">
+                            ibis-framework
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/icu-feedstock">
+                            icu
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/imagesize-feedstock">
+                            imagesize
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/imgurpython-feedstock">
+                            imgurpython
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/importlib-feedstock">
+                            importlib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/impyla-feedstock">
+                            impyla
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/inflection-feedstock">
+                            inflection
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/inkscape-feedstock">
+                            inkscape
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/invoke-feedstock">
+                            invoke
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ioos_qartod-feedstock">
+                            ioos_qartod
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipaddress-feedstock">
+                            ipaddress
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipdb-feedstock">
+                            ipdb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipycache-feedstock">
+                            ipycache
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipykernel-feedstock">
+                            ipykernel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipyleaflet-feedstock">
+                            ipyleaflet
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipyparallel-feedstock">
+                            ipyparallel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipython-feedstock">
+                            ipython
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipython_genutils-feedstock">
+                            ipython_genutils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ipywidgets-feedstock">
+                            ipywidgets
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/iris-feedstock">
+                            iris
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/isl-feedstock">
+                            isl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/iso8601-feedstock">
+                            iso8601
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/isodate-feedstock">
+                            isodate
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/isort-feedstock">
+                            isort
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/iterm2-tools-feedstock">
+                            iterm2-tools
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/iverilog-feedstock">
+                            iverilog
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jansson-feedstock">
+                            jansson
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jasper-feedstock">
+                            jasper
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jinja2-feedstock">
+                            jinja2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jinja2-time-feedstock">
+                            jinja2-time
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jmespath-feedstock">
+                            jmespath
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/joblib-feedstock">
+                            joblib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jpeg-feedstock">
+                            jpeg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jplephem-feedstock">
+                            jplephem
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jq-feedstock">
+                            jq
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jsanimation-feedstock">
+                            jsanimation
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jsmin-feedstock">
+                            jsmin
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/json-c-feedstock">
+                            json-c
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/json-rpc-feedstock">
+                            json-rpc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jsoncpp-feedstock">
+                            jsoncpp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jsonpatch-feedstock">
+                            jsonpatch
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jsonpointer-feedstock">
+                            jsonpointer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jsonschema-feedstock">
+                            jsonschema
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyter_client-feedstock">
+                            jupyter_client
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyter_console-feedstock">
+                            jupyter_console
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyter_contrib_core-feedstock">
+                            jupyter_contrib_core
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyter_contrib_nbextensions-feedstock">
+                            jupyter_contrib_nbextensions
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyter_core-feedstock">
+                            jupyter_core
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyter_nbextensions_configurator-feedstock">
+                            jupyter_nbextensions_configurator
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyterhub-feedstock">
+                            jupyterhub
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/jupyterlab-feedstock">
+                            jupyterlab
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/kealib-feedstock">
+                            kealib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/keras-feedstock">
+                            keras
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/keyring-feedstock">
+                            keyring
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/keystoneauth1-feedstock">
+                            keystoneauth1
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/kiwisolver-feedstock">
+                            kiwisolver
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/kombu-feedstock">
+                            kombu
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/krb5-feedstock">
+                            krb5
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/lapack-feedstock">
+                            lapack
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/lazy-object-proxy-feedstock">
+                            lazy-object-proxy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/lazyasd-feedstock">
+                            lazyasd
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/legit-feedstock">
+                            legit
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/leveldb-feedstock">
+                            leveldb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libarchive-feedstock">
+                            libarchive
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libatomic_ops-feedstock">
+                            libatomic_ops
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libblitz-feedstock">
+                            libblitz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libconda-feedstock">
+                            libconda
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libdap4-feedstock">
+                            libdap4
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libffi-feedstock">
+                            libffi
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libgd-feedstock">
+                            libgd
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libgfortran-feedstock">
+                            libgfortran
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libgsasl-feedstock">
+                            libgsasl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libhdfs3-feedstock">
+                            libhdfs3
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libiconv-feedstock">
+                            libiconv
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libmatio-feedstock">
+                            libmatio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libmemcached-feedstock">
+                            libmemcached
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libmo_unpack-feedstock">
+                            libmo_unpack
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libnetcdf-feedstock">
+                            libnetcdf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libntlm-feedstock">
+                            libntlm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libpng-feedstock">
+                            libpng
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libpq-feedstock">
+                            libpq
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libradolan-feedstock">
+                            libradolan
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/librosa-feedstock">
+                            librosa
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libsigcpp-feedstock">
+                            libsigcpp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libsodium-feedstock">
+                            libsodium
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libspatialindex-feedstock">
+                            libspatialindex
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libspatialite-feedstock">
+                            libspatialite
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libsvm-feedstock">
+                            libsvm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libtiff-feedstock">
+                            libtiff
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libtool-feedstock">
+                            libtool
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libunistring-feedstock">
+                            libunistring
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libuuid-feedstock">
+                            libuuid
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libxml2-feedstock">
+                            libxml2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/libxmlpp-feedstock">
+                            libxmlpp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/lifelines-feedstock">
+                            lifelines
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/line_profiler-feedstock">
+                            line_profiler
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/linecache2-feedstock">
+                            linecache2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/livereload-feedstock">
+                            livereload
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/lmdb-feedstock">
+                            lmdb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/lmfit-feedstock">
+                            lmfit
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/locket-feedstock">
+                            locket
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/logilab-common-feedstock">
+                            logilab-common
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/lua-feedstock">
+                            lua
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/luigi-feedstock">
+                            luigi
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/m2crypto-feedstock">
+                            m2crypto
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/m4-feedstock">
+                            m4
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mahotas-feedstock">
+                            mahotas
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mako-feedstock">
+                            mako
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/markupsafe-feedstock">
+                            markupsafe
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/matplotlib-feedstock">
+                            matplotlib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/matplotlib-venn-feedstock">
+                            matplotlib-venn
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mccabe-feedstock">
+                            mccabe
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/megaman-feedstock">
+                            megaman
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/memory_profiler-feedstock">
+                            memory_profiler
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mercurial-feedstock">
+                            mercurial
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/metafone-feedstock">
+                            metafone
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/metakernel-feedstock">
+                            metakernel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/metpy-feedstock">
+                            metpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/miktex-feedstock">
+                            miktex
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mingwpy-feedstock">
+                            mingwpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mistune-feedstock">
+                            mistune
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mkdocs-bootstrap-feedstock">
+                            mkdocs-bootstrap
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mkdocs-bootswatch-feedstock">
+                            mkdocs-bootswatch
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mkdocs-feedstock">
+                            mkdocs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mo_pack-feedstock">
+                            mo_pack
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mock-feedstock">
+                            mock
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/modflow2netcdf-feedstock">
+                            modflow2netcdf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mongoquery-feedstock">
+                            mongoquery
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/monotonic-feedstock">
+                            monotonic
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mox-feedstock">
+                            mox
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mpc-feedstock">
+                            mpc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mpfr-feedstock">
+                            mpfr
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mpich-feedstock">
+                            mpich
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mpir-feedstock">
+                            mpir
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mpl-probscale-feedstock">
+                            mpl-probscale
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mpld3-feedstock">
+                            mpld3
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mplexporter-feedstock">
+                            mplexporter
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mplleaflet-feedstock">
+                            mplleaflet
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mpmath-feedstock">
+                            mpmath
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/msinttypes-feedstock">
+                            msinttypes
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mss-feedstock">
+                            mss
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mtspec-feedstock">
+                            mtspec
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/munch-feedstock">
+                            munch
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/muparser-feedstock">
+                            muparser
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/mutagen-feedstock">
+                            mutagen
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/namedlist-feedstock">
+                            namedlist
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nb_anacondacloud-feedstock">
+                            nb_anacondacloud
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nb_conda-feedstock">
+                            nb_conda
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nb_conda_kernels-feedstock">
+                            nb_conda_kernels
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nbconvert-feedstock">
+                            nbconvert
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nbformat-feedstock">
+                            nbformat
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nbpresent-feedstock">
+                            nbpresent
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nc_time_axis-feedstock">
+                            nc_time_axis
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nco-feedstock">
+                            nco
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ncurses-feedstock">
+                            ncurses
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/netaddr-feedstock">
+                            netaddr
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/netcdf-cxx4-feedstock">
+                            netcdf-cxx4
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/netcdf-fortran-feedstock">
+                            netcdf-fortran
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/netcdf4-feedstock">
+                            netcdf4
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/netifaces-feedstock">
+                            netifaces
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/newrelic-feedstock">
+                            newrelic
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nfft-feedstock">
+                            nfft
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nibabel-feedstock">
+                            nibabel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nilearn-feedstock">
+                            nilearn
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ninja-feedstock">
+                            ninja
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nipype-feedstock">
+                            nipype
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nitime-feedstock">
+                            nitime
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nlopt-feedstock">
+                            nlopt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nn-feedstock">
+                            nn
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nodejs-feedstock">
+                            nodejs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nose-feedstock">
+                            nose
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nose-timer-feedstock">
+                            nose-timer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nose_parameterized-feedstock">
+                            nose_parameterized
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nosexcover-feedstock">
+                            nosexcover
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/notebook-feedstock">
+                            notebook
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nsis-feedstock">
+                            nsis
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/nuitka-feedstock">
+                            nuitka
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/numexpr-feedstock">
+                            numexpr
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/numpy-feedstock">
+                            numpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/numpy-indexed-feedstock">
+                            numpy-indexed
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/oauth2client-feedstock">
+                            oauth2client
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/oauthlib-feedstock">
+                            oauthlib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/obspy-feedstock">
+                            obspy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/obvious-ci-feedstock">
+                            obvious-ci
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/oceans-feedstock">
+                            oceans
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ocgis-feedstock">
+                            ocgis
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/oct2py-feedstock">
+                            oct2py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/olefile-feedstock">
+                            olefile
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/oniguruma-feedstock">
+                            oniguruma
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/openblas-feedstock">
+                            openblas
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/opencv-feedstock">
+                            opencv
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/openjpeg-feedstock">
+                            openjpeg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/openssl-feedstock">
+                            openssl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/openstacksdk-feedstock">
+                            openstacksdk
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/openturns-feedstock">
+                            openturns
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/orange3-feedstock">
+                            orange3
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ordered-set-feedstock">
+                            ordered-set
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ordereddict-feedstock">
+                            ordereddict
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/os-client-config-feedstock">
+                            os-client-config
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/otfftw-feedstock">
+                            otfftw
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/otmorris-feedstock">
+                            otmorris
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/otpmml-feedstock">
+                            otpmml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/otrobopt-feedstock">
+                            otrobopt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/otsvm-feedstock">
+                            otsvm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/owslib-feedstock">
+                            owslib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/packaging-feedstock">
+                            packaging
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/paegan-feedstock">
+                            paegan
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/paegan-transport-feedstock">
+                            paegan-transport
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/palettable-feedstock">
+                            palettable
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pamela-feedstock">
+                            pamela
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pandas-feedstock">
+                            pandas
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pandoc-feedstock">
+                            pandoc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pango-feedstock">
+                            pango
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/partd-feedstock">
+                            partd
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/paste-feedstock">
+                            paste
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pastescript-feedstock">
+                            pastescript
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/patchelf-feedstock">
+                            patchelf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/path.py-feedstock">
+                            path.py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/patsy-feedstock">
+                            patsy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pbr-feedstock">
+                            pbr
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pbzip2-feedstock">
+                            pbzip2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pcre-feedstock">
+                            pcre
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pdfminer-feedstock">
+                            pdfminer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/peewee-feedstock">
+                            peewee
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pelican-feedstock">
+                            pelican
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pep257-feedstock">
+                            pep257
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pep8-feedstock">
+                            pep8
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pep8-naming-feedstock">
+                            pep8-naming
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/perl-feedstock">
+                            perl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/petulant-bear-feedstock">
+                            petulant-bear
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pexpect-feedstock">
+                            pexpect
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/phonenumbers-feedstock">
+                            phonenumbers
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/phreeqpy-feedstock">
+                            phreeqpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pickleshare-feedstock">
+                            pickleshare
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pies-feedstock">
+                            pies
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pies2overrides-feedstock">
+                            pies2overrides
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pika-feedstock">
+                            pika
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pillow-feedstock">
+                            pillow
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pims-feedstock">
+                            pims
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pint-feedstock">
+                            pint
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pip-feedstock">
+                            pip
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pixman-feedstock">
+                            pixman
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pkg-config-feedstock">
+                            pkg-config
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pkginfo-feedstock">
+                            pkginfo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/plotly-feedstock">
+                            plotly
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/poliastro-feedstock">
+                            poliastro
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/port-for-feedstock">
+                            port-for
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/positional-feedstock">
+                            positional
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/postgresql-feedstock">
+                            postgresql
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/poyo-feedstock">
+                            poyo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/prefsync-feedstock">
+                            prefsync
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/premailer-feedstock">
+                            premailer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/prettytable-feedstock">
+                            prettytable
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/primesieve-feedstock">
+                            primesieve
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/probableparsing-feedstock">
+                            probableparsing
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/proj.4-feedstock">
+                            proj.4
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/prompt_toolkit-feedstock">
+                            prompt_toolkit
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/protobuf-feedstock">
+                            protobuf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/prov-feedstock">
+                            prov
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/psiturk-feedstock">
+                            psiturk
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/psutil-feedstock">
+                            psutil
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/psycopg2-feedstock">
+                            psycopg2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pthreads-win32-feedstock">
+                            pthreads-win32
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ptyprocess-feedstock">
+                            ptyprocess
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pudb-feedstock">
+                            pudb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pv-feedstock">
+                            pv
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pvlib-python-feedstock">
+                            pvlib-python
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/py4j-feedstock">
+                            py4j
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyamg-feedstock">
+                            pyamg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyaml-feedstock">
+                            pyaml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyasn1-feedstock">
+                            pyasn1
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyaxiom-feedstock">
+                            pyaxiom
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pybind11-feedstock">
+                            pybind11
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pycalphad-feedstock">
+                            pycalphad
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pycapnp-feedstock">
+                            pycapnp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pycodestyle-feedstock">
+                            pycodestyle
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pycosat-feedstock">
+                            pycosat
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pycrypto-feedstock">
+                            pycrypto
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pycsw-feedstock">
+                            pycsw
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pydap-feedstock">
+                            pydap
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pydicom-feedstock">
+                            pydicom
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pydocstyle-feedstock">
+                            pydocstyle
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pydoe-feedstock">
+                            pydoe
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pydotplus-feedstock">
+                            pydotplus
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pydruid-feedstock">
+                            pydruid
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pydy-feedstock">
+                            pydy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyelftools-feedstock">
+                            pyelftools
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyepsg-feedstock">
+                            pyepsg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyface-feedstock">
+                            pyface
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyferret-feedstock">
+                            pyferret
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyfftw-feedstock">
+                            pyfftw
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyfive-feedstock">
+                            pyfive
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyflakes-feedstock">
+                            pyflakes
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyflann-feedstock">
+                            pyflann
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygc-feedstock">
+                            pygc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygdp-feedstock">
+                            pygdp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygeogrids-feedstock">
+                            pygeogrids
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygeoif-feedstock">
+                            pygeoif
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygithub-feedstock">
+                            pygithub
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyglet-feedstock">
+                            pyglet
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygments-feedstock">
+                            pygments
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygrib-feedstock">
+                            pygrib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygridgen-feedstock">
+                            pygridgen
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pygridtools-feedstock">
+                            pygridtools
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyhamcrest-feedstock">
+                            pyhamcrest
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyhdf-feedstock">
+                            pyhdf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyhocon-feedstock">
+                            pyhocon
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyhum-feedstock">
+                            pyhum
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyinotify-feedstock">
+                            pyinotify
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyinstaller-feedstock">
+                            pyinstaller
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyjwt-feedstock">
+                            pyjwt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pykalman-feedstock">
+                            pykalman
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pykdtree-feedstock">
+                            pykdtree
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyke-feedstock">
+                            pyke
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pykml-feedstock">
+                            pykml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pykwalify-feedstock">
+                            pykwalify
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pylibmc-feedstock">
+                            pylibmc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pylint-feedstock">
+                            pylint
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pylint-plugin-utils-feedstock">
+                            pylint-plugin-utils
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pymatbridge-feedstock">
+                            pymatbridge
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pymeasure-feedstock">
+                            pymeasure
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pymongo-feedstock">
+                            pymongo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyncml-feedstock">
+                            pyncml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pynco-feedstock">
+                            pynco
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pynfft-feedstock">
+                            pynfft
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pynio-feedstock">
+                            pynio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyomo-feedstock">
+                            pyomo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyomo.extras-feedstock">
+                            pyomo.extras
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyoos-feedstock">
+                            pyoos
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyopcode-feedstock">
+                            pyopcode
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyopengl-feedstock">
+                            pyopengl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pypandoc-feedstock">
+                            pypandoc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyparsing-feedstock">
+                            pyparsing
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pypdf2-feedstock">
+                            pypdf2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pypolyagamma-feedstock">
+                            pypolyagamma
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyproj-feedstock">
+                            pyproj
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyresample-feedstock">
+                            pyresample
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyro4-feedstock">
+                            pyro4
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyroma-feedstock">
+                            pyroma
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pysal-feedstock">
+                            pysal
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyscaffold-feedstock">
+                            pyscaffold
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyseidon-feedstock">
+                            pyseidon
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pysgrid-feedstock">
+                            pysgrid
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyshp-feedstock">
+                            pyshp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pysmbclient-feedstock">
+                            pysmbclient
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pysocks-feedstock">
+                            pysocks
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyspharm-feedstock">
+                            pyspharm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pystache-feedstock">
+                            pystache
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytables-feedstock">
+                            pytables
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-benchmark-feedstock">
+                            pytest-benchmark
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-cov-feedstock">
+                            pytest-cov
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-django-feedstock">
+                            pytest-django
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-faulthandler-feedstock">
+                            pytest-faulthandler
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-feedstock">
+                            pytest
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-mock-feedstock">
+                            pytest-mock
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-mpl-feedstock">
+                            pytest-mpl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-qt-feedstock">
+                            pytest-qt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-runner-feedstock">
+                            pytest-runner
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-sftpserver-feedstock">
+                            pytest-sftpserver
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytest-xdist-feedstock">
+                            pytest-xdist
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-avro-feedstock">
+                            python-avro
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-cdo-feedstock">
+                            python-cdo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-coveralls-feedstock">
+                            python-coveralls
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-crfsuite-feedstock">
+                            python-crfsuite
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-dateutil-feedstock">
+                            python-dateutil
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-decorator-feedstock">
+                            python-decorator
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-docx-feedstock">
+                            python-docx
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-drmaa-feedstock">
+                            python-drmaa
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-eccodes-feedstock">
+                            python-eccodes
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-ecmwf_grib-feedstock">
+                            python-ecmwf_grib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-editor-feedstock">
+                            python-editor
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-feedstock">
+                            python
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-gflags-feedstock">
+                            python-gflags
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-gnupg-feedstock">
+                            python-gnupg
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-hdfs-feedstock">
+                            python-hdfs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-leveldb-feedstock">
+                            python-leveldb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-levenshtein-feedstock">
+                            python-levenshtein
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-marisa-trie-feedstock">
+                            python-marisa-trie
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-mimeparse-feedstock">
+                            python-mimeparse
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-neo-feedstock">
+                            python-neo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-pathlib2-feedstock">
+                            python-pathlib2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-pptx-feedstock">
+                            python-pptx
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-primesieve-feedstock">
+                            python-primesieve
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-simplegeneric-feedstock">
+                            python-simplegeneric
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-snappy-feedstock">
+                            python-snappy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-spams-feedstock">
+                            python-spams
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-symengine-feedstock">
+                            python-symengine
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/python-ternary-feedstock">
+                            python-ternary
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pythreejs-feedstock">
+                            pythreejs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytmatrix-feedstock">
+                            pytmatrix
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytools-feedstock">
+                            pytools
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytrie-feedstock">
+                            pytrie
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pytz-feedstock">
+                            pytz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyugrid-feedstock">
+                            pyugrid
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyutilib-feedstock">
+                            pyutilib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyvisa-feedstock">
+                            pyvisa
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pywavelets-feedstock">
+                            pywavelets
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pywebhdfs-feedstock">
+                            pywebhdfs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyyaml-feedstock">
+                            pyyaml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/pyzmq-feedstock">
+                            pyzmq
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qds-sdk-feedstock">
+                            qds-sdk
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qimage2ndarray-feedstock">
+                            qimage2ndarray
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qrcode-feedstock">
+                            qrcode
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qt-feedstock">
+                            qt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qt_binder-feedstock">
+                            qt_binder
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qtconsole-feedstock">
+                            qtconsole
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qtpy-feedstock">
+                            qtpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/quantecon-feedstock">
+                            quantecon
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/quantities-feedstock">
+                            quantities
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qutip-feedstock">
+                            qutip
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qwt-feedstock">
+                            qwt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/qwtpolar-feedstock">
+                            qwtpolar
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rank_filter-feedstock">
+                            rank_filter
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rasterio-feedstock">
+                            rasterio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rasterstats-feedstock">
+                            rasterstats
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/readline-feedstock">
+                            readline
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/redis-py-feedstock">
+                            redis-py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/regex-feedstock">
+                            regex
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rejected-feedstock">
+                            rejected
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/reproject-feedstock">
+                            reproject
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/requests-feedstock">
+                            requests
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/requests-futures-feedstock">
+                            requests-futures
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/requests-oauthlib-feedstock">
+                            requests-oauthlib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/requests-toolbelt-feedstock">
+                            requests-toolbelt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/requestsexceptions-feedstock">
+                            requestsexceptions
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/requirements-detector-feedstock">
+                            requirements-detector
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/resampy-feedstock">
+                            resampy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rfc3986-feedstock">
+                            rfc3986
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rios-feedstock">
+                            rios
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rq-feedstock">
+                            rq
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rsa-feedstock">
+                            rsa
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/rtree-feedstock">
+                            rtree
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ruamel.ordereddict-feedstock">
+                            ruamel.ordereddict
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ruamel.yaml-feedstock">
+                            ruamel.yaml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ruamel_yaml-feedstock">
+                            ruamel_yaml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/runipy-feedstock">
+                            runipy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/s3fs-feedstock">
+                            s3fs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/s3transfer-feedstock">
+                            s3transfer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/salt-feedstock">
+                            salt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scandir-feedstock">
+                            scandir
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scikit-beam-feedstock">
+                            scikit-beam
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scikit-bio-feedstock">
+                            scikit-bio
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scikit-image-feedstock">
+                            scikit-image
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scikit-learn-feedstock">
+                            scikit-learn
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scikit-sparse-feedstock">
+                            scikit-sparse
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scikit-umfpack-feedstock">
+                            scikit-umfpack
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scipy-feedstock">
+                            scipy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/scp-feedstock">
+                            scp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/seaborn-feedstock">
+                            seaborn
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/seawater-feedstock">
+                            seawater
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sed-feedstock">
+                            sed
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/selenium-feedstock">
+                            selenium
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/serpent-feedstock">
+                            serpent
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/setoptconf-feedstock">
+                            setoptconf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/setproctitle-feedstock">
+                            setproctitle
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/setuptools-feedstock">
+                            setuptools
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/setuptools-git-feedstock">
+                            setuptools-git
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/setuptools_scm-feedstock">
+                            setuptools_scm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/shapely-feedstock">
+                            shapely
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/simbody-feedstock">
+                            simbody
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/simplekml-feedstock">
+                            simplekml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/singledispatch-feedstock">
+                            singledispatch
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sip-feedstock">
+                            sip
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/siphon-feedstock">
+                            siphon
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/six-feedstock">
+                            six
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sklearn-contrib-lightning-feedstock">
+                            sklearn-contrib-lightning
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/slackclient-feedstock">
+                            slackclient
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/slacker-feedstock">
+                            slacker
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/slda-feedstock">
+                            slda
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/slicerator-feedstock">
+                            slicerator
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/smmap-feedstock">
+                            smmap
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/snakebite-feedstock">
+                            snakebite
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/snakefood-feedstock">
+                            snakefood
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/snappy-feedstock">
+                            snappy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/snowballstemmer-feedstock">
+                            snowballstemmer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/snuggs-feedstock">
+                            snuggs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sortedcontainers-feedstock">
+                            sortedcontainers
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sound_field_analysis-feedstock">
+                            sound_field_analysis
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sox-feedstock">
+                            sox
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sparsehash-feedstock">
+                            sparsehash
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/speaklater-feedstock">
+                            speaklater
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/speechrecognition-feedstock">
+                            speechrecognition
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/spefile-feedstock">
+                            spefile
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sphinx-argparse-feedstock">
+                            sphinx-argparse
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sphinx-bootstrap-theme-feedstock">
+                            sphinx-bootstrap-theme
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sphinx-feedstock">
+                            sphinx
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sphinx_rtd_theme-feedstock">
+                            sphinx_rtd_theme
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sphinxcontrib-autoprogram-feedstock">
+                            sphinxcontrib-autoprogram
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/splauncher-feedstock">
+                            splauncher
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/spyder-feedstock">
+                            spyder
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/spylon-feedstock">
+                            spylon
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/spyne-feedstock">
+                            spyne
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/spyre-feedstock">
+                            spyre
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sqlite-feedstock">
+                            sqlite
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/srtm.py-feedstock">
+                            srtm.py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ssl_match_hostname-feedstock">
+                            ssl_match_hostname
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/stack-feedstock">
+                            stack
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/static-feedstock">
+                            static
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/statsd-feedstock">
+                            statsd
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/statsmodels-feedstock">
+                            statsmodels
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/statuspage-feedstock">
+                            statuspage
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/stdlib-list-feedstock">
+                            stdlib-list
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/stevedore-feedstock">
+                            stevedore
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/structlog-feedstock">
+                            structlog
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/subprocess32-feedstock">
+                            subprocess32
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/suds-jurko-feedstock">
+                            suds-jurko
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/suitesparse-feedstock">
+                            suitesparse
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sunpy-feedstock">
+                            sunpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/super_state_machine-feedstock">
+                            super_state_machine
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/supervisor-feedstock">
+                            supervisor
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/swig-feedstock">
+                            swig
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/symengine-feedstock">
+                            symengine
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/sympy-feedstock">
+                            sympy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tabulate-feedstock">
+                            tabulate
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tangelo-feedstock">
+                            tangelo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tbb-feedstock">
+                            tbb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tempita-feedstock">
+                            tempita
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tensorflow-feedstock">
+                            tensorflow
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/termcolor-feedstock">
+                            termcolor
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/terminado-feedstock">
+                            terminado
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/testfixtures-feedstock">
+                            testfixtures
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/texinfo-feedstock">
+                            texinfo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/texlive-core-feedstock">
+                            texlive-core
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/theano-feedstock">
+                            theano
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/thinkx-feedstock">
+                            thinkx
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/thredds_crawler-feedstock">
+                            thredds_crawler
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/thrift-cpp-feedstock">
+                            thrift-cpp
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/thrift-feedstock">
+                            thrift
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/thriftpy-feedstock">
+                            thriftpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tifffile-feedstock">
+                            tifffile
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tika-feedstock">
+                            tika
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tinydb-feedstock">
+                            tinydb
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tk-feedstock">
+                            tk
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tlslite-feedstock">
+                            tlslite
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tomopy-feedstock">
+                            tomopy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/toolchain-feedstock">
+                            toolchain
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/toolz-feedstock">
+                            toolz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tornado-feedstock">
+                            tornado
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tqdm-feedstock">
+                            tqdm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/traitlets-feedstock">
+                            traitlets
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/traits-feedstock">
+                            traits
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/traitsui-feedstock">
+                            traitsui
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/trmm_rsl-feedstock">
+                            trmm_rsl
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tuiview-feedstock">
+                            tuiview
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/typing-feedstock">
+                            typing
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/tzlocal-feedstock">
+                            tzlocal
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/u3d-feedstock">
+                            u3d
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ua-parser-feedstock">
+                            ua-parser
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/udunits2-feedstock">
+                            udunits2
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ulmo-feedstock">
+                            ulmo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/uncertainties-feedstock">
+                            uncertainties
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/unidecode-feedstock">
+                            unidecode
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/uritemplate-feedstock">
+                            uritemplate
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/uritemplate.py-feedstock">
+                            uritemplate.py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/urllib3-feedstock">
+                            urllib3
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/urwid-feedstock">
+                            urwid
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/usaddress-feedstock">
+                            usaddress
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/user-agents-feedstock">
+                            user-agents
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/utide-feedstock">
+                            utide
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/uwsgi-feedstock">
+                            uwsgi
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/valideer-feedstock">
+                            valideer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vc-feedstock">
+                            vc
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vcrpy-feedstock">
+                            vcrpy
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vcversioner-feedstock">
+                            vcversioner
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vega-feedstock">
+                            vega
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/verboselogs-feedstock">
+                            verboselogs
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/versioneer-feedstock">
+                            versioneer
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vertica-python-feedstock">
+                            vertica-python
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vigra-feedstock">
+                            vigra
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vincent-feedstock">
+                            vincent
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vlfeat-feedstock">
+                            vlfeat
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/voluptuous-feedstock">
+                            voluptuous
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vs2015_runtime-feedstock">
+                            vs2015_runtime
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vtk-feedstock">
+                            vtk
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/vulture-feedstock">
+                            vulture
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/waf-feedstock">
+                            waf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/warlock-feedstock">
+                            warlock
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wcsaxes-feedstock">
+                            wcsaxes
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wcwidth-feedstock">
+                            wcwidth
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/webcolors-feedstock">
+                            webcolors
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/websocket-client-feedstock">
+                            websocket-client
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wera2netcdf-feedstock">
+                            wera2netcdf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wheel-feedstock">
+                            wheel
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/whichcraft-feedstock">
+                            whichcraft
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wicken-feedstock">
+                            wicken
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/widgetsnbextension-feedstock">
+                            widgetsnbextension
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/win_unicode_console-feedstock">
+                            win_unicode_console
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wincertstore-feedstock">
+                            wincertstore
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/windrose-feedstock">
+                            windrose
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/windspharm-feedstock">
+                            windspharm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wordcloud-feedstock">
+                            wordcloud
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wradlib-feedstock">
+                            wradlib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wrapt-feedstock">
+                            wrapt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/ws4py-feedstock">
+                            ws4py
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/wtforms-appengine-feedstock">
+                            wtforms-appengine
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/x264-feedstock">
+                            x264
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xarray-feedstock">
+                            xarray
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xerces-c-feedstock">
+                            xerces-c
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xo-feedstock">
+                            xo
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xonsh-feedstock">
+                            xonsh
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xray-vision-feedstock">
+                            xray-vision
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xraylib-feedstock">
+                            xraylib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xvfbwrapper-feedstock">
+                            xvfbwrapper
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/xz-feedstock">
+                            xz
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/y_serial-feedstock">
+                            y_serial
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/yaml-feedstock">
+                            yaml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/yaml2ncml-feedstock">
+                            yaml2ncml
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/yapf-feedstock">
+                            yapf
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/yasm-feedstock">
+                            yasm
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/yt-feedstock">
+                            yt
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/zarr-feedstock">
+                            zarr
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/zeromq-feedstock">
+                            zeromq
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/zlib-feedstock">
+                            zlib
+                        </a>
+                    </li>
+
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/zwatershed-feedstock">
+                            zwatershed
+                        </a>
+                    </li>
+
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container text-center">
+            <p>
+            <a href="https://conda-forge.github.io">Home</a> |
+            <a href="index.html#about">About</a> |
+            <a href="index.html#contribute">Contribute</a> |
+            <a href="feedstocks.html">Feedstocks</a> |
+            <a href="https://github.com/conda-forge">conda-forge on GitHub</a>
+            </p>
+            <br/>
+            <p class="small">
+            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><a href="https://conda-forge.github.io">conda-forge.github.io</a> is licensed under a <br /> <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+            </p>
+        </div>
+    </footer>
+
+    <!-- jQuery -->
+    <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+
+    <!-- Bootstrap Core JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+
+    <!-- Custom Theme JavaScript -->
+    <script src="js/theme.js"></script>
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-75621500-1', 'auto');
+      ga('send', 'pageview');
+
+    </script>
+
+</body>
+
+</html>

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>conda-forge feedstocks | community driven packaging for conda</title>
+
+    <!-- Bootstrap Core CSS -->
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="css/theme.css" rel="stylesheet">
+
+    <!-- Custom Fonts -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link hrefs="http://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+        <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+</head>
+
+<body id="page-top" data-spy="scroll" data-target=".navbar-fixed-top">
+
+    <!-- Navigation -->
+    <nav class="navbar navbar-custom navbar-fixed-top" role="navigation">
+        <div class="container semi-black-alpha" role="navigation">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
+                    <i class="fa fa-bars"></i>
+                </button>
+                <a class="navbar-brand page-scroll" href="./#page-top">
+                    <i><img src="img/anvil_white.png" alt="An anvil" style="height: 1em;"></i>  <span class="light">conda-forge</span>
+                </a>
+            </div>
+
+            <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
+                <ul class="nav navbar-nav">
+                    <li>
+                        <a class="page-scroll" href="./#about">About</a>
+                    </li>
+                    <li>
+                        <a class="page-scroll" href="./#contribute">Contribute</a>
+                    </li>
+                    <li class="active">
+                        <a href="feedstocks.html">Packages</a>
+                    </li>
+                    <li>
+                        <a href="./status">Status</a>
+                    </li>
+
+                </ul>
+            </div>
+            <!-- /.navbar-collapse -->
+        </div>
+        <!-- /.container -->
+    </nav>
+
+    <!-- About Section -->
+    <section id="feedstocks" class="container content-section">
+        <div class="row">
+            <div class="col-lg-8 col-lg-offset-2">
+                <h2 class="text-center">Feedstocks on conda-forge</h2>
+                <ul class="list-group">
+{% for feedstock in gh_feedstocks %}
+                    <li class="list-group-item">
+                        <a href="https://github.com/conda-forge/{{ feedstock.name }}">
+                            {{ feedstock.package_name }}
+                        </a>
+                    </li>
+{% endfor %}
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container text-center">
+            <p>
+            <a href="https://conda-forge.github.io">Home</a> |
+            <a href="index.html#about">About</a> |
+            <a href="index.html#contribute">Contribute</a> |
+            <a href="feedstocks.html">Feedstocks</a> |
+            <a href="https://github.com/conda-forge">conda-forge on GitHub</a>
+            </p>
+            <br/>
+            <p class="small">
+            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><a href="https://conda-forge.github.io">conda-forge.github.io</a> is licensed under a <br /> <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+            </p>
+        </div>
+    </footer>
+
+    <!-- jQuery -->
+    <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+
+    <!-- Bootstrap Core JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+
+    <!-- Custom Theme JavaScript -->
+    <script src="js/theme.js"></script>
+
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-75621500-1', 'auto');
+      ga('send', 'pageview');
+
+    </script>
+
+</body>
+
+</html>

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env conda-execute
+
+# conda execute
+# env:
+#  - python
+#  - conda-smithy
+# channels:
+#  - conda-forge
+# run_with: python
+
+import os
+
+import conda_smithy.feedstocks as feedstocks
+
+from jinja2 import Environment, FileSystemLoader
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Generate the conda-forge html.')
+parser.add_argument('--html-source', help="The location of the conda-forge.github.io checkout.",
+                   default=os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+args = parser.parse_args()
+
+html_source = args.html_source
+loader = FileSystemLoader(html_source)
+env = Environment(loader=loader)
+
+context = {}
+context['gh_feedstocks'] = feedstocks.feedstock_repos('conda-forge')
+
+
+tmpl = env.get_template('index.html.tmpl')
+with open(os.path.join(html_source, 'index.html'), 'w') as fh:
+    fh.write(tmpl.render(context))

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env conda-execute
+
+# conda execute
+# env:
+#  - git
+#  - python
+#  - conda-smithy
+#  - gitpython
+# channels:
+#  - conda-forge
+# run_with: python
+
+import os
+import shutil
+
+import conda_smithy.feedstocks as feedstocks
+from git import Repo
+from git.exc import GitCommandError
+
+import argparse
+
+import warnings
+
+parser = argparse.ArgumentParser(description='Update the conda-forge/feedstocks repo.')
+parser.add_argument('feedstocks_repo', help="The location of the checked out conda-forge/feedstocks repo.")
+
+args = parser.parse_args()
+
+feedstocks_repo = Repo(args.feedstocks_repo)
+
+forge_feedstocks = feedstocks.feedstock_repos('conda-forge')
+
+# Identify the submodule names which lie withing the repo.
+submodules = {sm.name: sm for sm in feedstocks_repo.submodules}
+
+for feedstock in forge_feedstocks:
+    repo_subdir = os.path.join('feedstocks', feedstock.package_name)
+    abs_subdir = os.path.join(feedstocks_repo.working_tree_dir, repo_subdir)
+    if not os.path.exists(abs_subdir):
+        print('Adding {} to submodules.'.format(feedstock.package_name))
+
+        # For situations where the submodule already exists, but not in the expected locations, just
+        # remove it, and re-add.
+        if feedstock.package_name in submodules:
+            feedstocks_repo.submodules[feedstock.package_name].remove()
+
+        # Add the new submodule.
+        try:
+            feedstocks_repo.git.submodule(
+                "add",
+                "--name",
+                feedstock.package_name,
+                feedstock.clone_url,
+                repo_subdir
+            )
+        except GitCommandError:
+            warnings.warn(
+                    "Unable to add the submodule {}. "
+                    "This is likely because the repo has no commits, "
+                    "which likely means something went wrong with feedstock generation. "
+                    "Will skip adding this submodule and continue.".format(feedstock.package_name)
+            )
+            shutil.rmtree(abs_subdir)
+
+
+# Pick out the feedstocks which exist on the repo, but are no longer on conda-forge.
+to_be_deleted = set(submodules.keys()) - set(repo.package_name for repo in forge_feedstocks)
+for package_name in to_be_deleted:
+    print("Removing {}.".format(package_name))
+    submodule = submodules[package_name].remove()
+
+feedstocks_repo.submodule_update(recursive=False)
+feedstocks_repo.git.submodule('foreach', 'git', 'pull', 'origin', 'master')

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env conda-execute
+
+# conda execute
+# env:
+#  - python
+#  - conda-smithy
+#  - pygithub 1.*
+#  - six
+#  - conda-build 1.20.1
+# channels:
+#  - conda-forge
+# run_with: python
+
+import argparse
+import collections
+import os
+import six
+
+from github import Github
+import github
+import yaml
+from conda_build.metadata import MetaData
+
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('feedstocks_clone', help="The location of the feedstocks directory within the conda-forge/feedstocks clone.")
+
+args = parser.parse_args()
+
+from conda_smithy.github import gh_token
+
+
+token = gh_token()
+
+gh = Github(token)
+
+conda_forge = gh.get_organization('conda-forge')
+teams = {team.name: team for team in conda_forge.get_teams()}
+
+feedstocks_path = args.feedstocks_clone
+
+
+def create_team(org, name, description, repos):
+    # PyGithub creates secret teams, and has no way of turning that off! :(
+    post_parameters = {
+        "name": name,
+        "description": description,
+        "privacy": "closed",
+    }
+    post_parameters["repo_names"] = [element._identity for element in repos]
+    headers, data = org._requester.requestJsonAndCheck(
+        "POST",
+        org.url + "/teams",
+        input=post_parameters
+    )
+    return github.Team.Team(org._requester, headers, data, completed=True)
+
+
+packages_visited = set()
+
+all_members = set()
+from random import choice
+superlative = ['awesome', 'slick', 'formidable', 'awe-inspiring', 'breathtaking',
+               'magnificent', 'wonderous', 'stunning', 'astonishing', 'superb',
+               'splendid', 'impressive', 'unbeatable', 'excellent', 'top', 'outstanding',
+               'exalted', 'standout', 'smashing']
+
+# Go through each of the feedstocks and ensure that the team is up to date and that
+# there is nobody in the team which doesn't belong (i.e. isn't in the maintainers list).
+for package_name in os.listdir(feedstocks_path):
+    print("Checking {}".format(package_name))
+    packages_visited.add(package_name)
+    feedstock = os.path.join(feedstocks_path, package_name)
+    recipe = os.path.join(feedstock, 'recipe', 'meta.yaml')
+
+    if not os.path.exists(recipe):
+        print("The {} feedstock is recipe less".format(package_name))
+        continue
+    meta = MetaData(os.path.dirname(recipe))
+
+    contributors = meta.meta.get('extra', {}).get('recipe-maintainers', [])
+    if not isinstance(contributors, list):
+        # Deal with a contribution list which has dashes but no spaces
+        # (e.g. https://github.com/conda-forge/pandoc-feedstock/issues/1)
+        contributors = [contributors.lstrip('-')]
+    contributors = set(handle.lower() for handle in contributors)
+    all_members.update(contributors)
+
+    # Get the github repo for this feedstock.
+    repo = conda_forge.get_repo('{}-feedstock'.format(package_name))
+
+    # If the team already exists, get hold of it.
+    team = teams.get(package_name)
+    if not team:
+        team = create_team(conda_forge, package_name.lower(),
+                           'The {} {} contributors!'.format(choice(superlative), package_name),
+                           [repo])
+        teams[package_name] = team
+    # Ensure that we have merge rights on the repo for this team.
+    url = team.url + "/repos/" + repo._identity
+    team._requester.requestJsonAndCheck("PUT", url, input={"permission": "push"})
+
+    current_members = team.get_members()
+    member_handles = set([member.login.lower() for member in current_members])
+    for new_member in contributors - member_handles:
+        headers, data = team._requester.requestJsonAndCheck(
+                                       "PUT",
+                                        team.url + "/memberships/" + new_member)
+    for old_member in member_handles - contributors:
+        print("AN OLD MEMBER ({}) NEEDS TO BE REMOVED FROM {}".format(old_member, repo._identity))
+        # The following works, it is just a bit scary!
+#        headers, data = team._requester.requestJsonAndCheck(
+#                                  "DELETE",
+#                                  team.url + "/memberships/" + old_member)
+
+
+# Create and administer the all-members team.
+team = teams.get('all-members')
+if not team:
+    team = create_team(conda_forge, 'all-members',
+                       'All of the awesome conda-forge contributors!', [])
+
+current_members = team.get_members()
+member_handles = set([member.login.lower() for member in current_members])
+for new_member in all_members - member_handles:
+    headers, data = team._requester.requestJsonAndCheck(
+                                   "PUT",
+                                    team.url + "/memberships/" + new_member)
+for old_member in member_handles - all_members:
+    print("AN OLD MEMBER ({}) NEEDS TO BE REMOVED FROM all-members".format(old_member))
+
+
+
+# Remove any teams which don't belong any more (because there is no longer a feedstock).
+for team_to_remove in set(teams.keys()) - set(packages_visited):
+    if team_to_remove in ['Core',
+                          'conda-forge.github.io',
+                          'all-members',
+                          'conda-forge-anvil',
+                          'conda-forge-webservices']:
+        print('Keeping ', team_to_remove)
+        continue
+    print("THE {} TEAM NEEDS TO BE REMOVED.".format(team_to_remove))
+    # The following works, it is just a bit scary!
+#    teams[team_to_remove].delete()


### PR DESCRIPTION
Partially solves https://github.com/conda-forge/conda-forge.github.io/issues/214

This is part of the proposal in issue ( https://github.com/conda-forge/conda-forge.github.io/issues/214 ) to break out feedstocks updates both in terms of submodules and the listing into this repo. CI on this repo will handle all updates. Given this repo seldom requires any direct involvement unlike the webpage repo, this should cutdown on build noise at the webpage repo. Further all scripts associated with updating this repo would now be present in it. This should allow for a better separation of concerns.

Currently this is only somewhat tested and probably could use some more eyes to review.

Have tested the feedstocks update and webpage update portions. Both seem to work fine. Haven't run the team update portion, but I don't expect any real surprises.

Also have configured the GitHub pages for this repo to point to `master`. This way we can use one branch to hold the feedstocks and host the webpage.

cc @pelson 
