### PR TITLE
Specify master as upstream for all submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,9768 +21,13023 @@
 [submodule "conda-build-all"]
 	url = https://github.com/conda-forge/conda-build-all-feedstock.git
 	path = feedstocks/conda-build-all
+	branch = refs/heads/master
 [submodule "pyproj"]
 	url = https://github.com/conda-forge/pyproj-feedstock.git
 	path = feedstocks/pyproj
+	branch = refs/heads/master
 [submodule "wcwidth"]
 	url = https://github.com/conda-forge/wcwidth-feedstock.git
 	path = feedstocks/wcwidth
+	branch = refs/heads/master
 [submodule "conda-execute"]
 	url = https://github.com/conda-forge/conda-execute-feedstock.git
 	path = feedstocks/conda-execute
+	branch = refs/heads/master
 [submodule "xonsh"]
 	url = https://github.com/conda-forge/xonsh-feedstock.git
 	path = feedstocks/xonsh
+	branch = refs/heads/master
 [submodule "ruamel.ordereddict"]
 	url = https://github.com/conda-forge/ruamel.ordereddict-feedstock.git
 	path = feedstocks/ruamel.ordereddict
+	branch = refs/heads/master
 [submodule "ruamel.yaml"]
 	url = https://github.com/conda-forge/ruamel.yaml-feedstock.git
 	path = feedstocks/ruamel.yaml
+	branch = refs/heads/master
 [submodule "setproctitle"]
 	url = https://github.com/conda-forge/setproctitle-feedstock.git
 	path = feedstocks/setproctitle
+	branch = refs/heads/master
 [submodule "smmap"]
 	url = https://github.com/conda-forge/smmap-feedstock.git
 	path = feedstocks/smmap
+	branch = refs/heads/master
 [submodule "functools32"]
 	url = https://github.com/conda-forge/functools32-feedstock.git
 	path = feedstocks/functools32
+	branch = refs/heads/master
 [submodule "gitpython"]
 	url = https://github.com/conda-forge/gitpython-feedstock.git
 	path = feedstocks/gitpython
+	branch = refs/heads/master
 [submodule "msinttypes"]
 	url = https://github.com/conda-forge/msinttypes-feedstock.git
 	path = feedstocks/msinttypes
+	branch = refs/heads/master
 [submodule "pygithub"]
 	url = https://github.com/conda-forge/pygithub-feedstock.git
 	path = feedstocks/pygithub
+	branch = refs/heads/master
 [submodule "tifffile"]
 	url = https://github.com/conda-forge/tifffile-feedstock.git
 	path = feedstocks/tifffile
+	branch = refs/heads/master
 [submodule "metpy"]
 	url = https://github.com/conda-forge/metpy-feedstock.git
 	path = feedstocks/metpy
+	branch = refs/heads/master
 [submodule "pint"]
 	url = https://github.com/conda-forge/pint-feedstock.git
 	path = feedstocks/pint
+	branch = refs/heads/master
 [submodule "protobuf"]
 	url = https://github.com/conda-forge/protobuf-feedstock.git
 	path = feedstocks/protobuf
+	branch = refs/heads/master
 [submodule "siphon"]
 	url = https://github.com/conda-forge/siphon-feedstock.git
 	path = feedstocks/siphon
+	branch = refs/heads/master
 [submodule "conda-testenv"]
 	url = https://github.com/conda-forge/conda-testenv-feedstock.git
 	path = feedstocks/conda-testenv
+	branch = refs/heads/master
 [submodule "arm_pyart"]
 	url = https://github.com/conda-forge/arm_pyart-feedstock.git
 	path = feedstocks/arm_pyart
+	branch = refs/heads/master
 [submodule "artview"]
 	url = https://github.com/conda-forge/artview-feedstock.git
 	path = feedstocks/artview
+	branch = refs/heads/master
 [submodule "contextlib2"]
 	url = https://github.com/conda-forge/contextlib2-feedstock.git
 	path = feedstocks/contextlib2
+	branch = refs/heads/master
 [submodule "geos"]
 	url = https://github.com/conda-forge/geos-feedstock.git
 	path = feedstocks/geos
+	branch = refs/heads/master
 [submodule "gitdb"]
 	url = https://github.com/conda-forge/gitdb-feedstock.git
 	path = feedstocks/gitdb
+	branch = refs/heads/master
 [submodule "mingwpy"]
 	url = https://github.com/conda-forge/mingwpy-feedstock.git
 	path = feedstocks/mingwpy
+	branch = refs/heads/master
 [submodule "netcdf4"]
 	url = https://github.com/conda-forge/netcdf4-feedstock.git
 	path = feedstocks/netcdf4
+	branch = refs/heads/master
 [submodule "pep8-naming"]
 	url = https://github.com/conda-forge/pep8-naming-feedstock.git
 	path = feedstocks/pep8-naming
+	branch = refs/heads/master
 [submodule "prompt_toolkit"]
 	url = https://github.com/conda-forge/prompt_toolkit-feedstock.git
 	path = feedstocks/prompt_toolkit
+	branch = refs/heads/master
 [submodule "qutip"]
 	url = https://github.com/conda-forge/qutip-feedstock.git
 	path = feedstocks/qutip
+	branch = refs/heads/master
 [submodule "shapely"]
 	url = https://github.com/conda-forge/shapely-feedstock.git
 	path = feedstocks/shapely
+	branch = refs/heads/master
 [submodule "tensorflow"]
 	url = https://github.com/conda-forge/tensorflow-feedstock.git
 	path = feedstocks/tensorflow
+	branch = refs/heads/master
 [submodule "trmm_rsl"]
 	url = https://github.com/conda-forge/trmm_rsl-feedstock.git
 	path = feedstocks/trmm_rsl
+	branch = refs/heads/master
 [submodule "vcrpy"]
 	url = https://github.com/conda-forge/vcrpy-feedstock.git
 	path = feedstocks/vcrpy
+	branch = refs/heads/master
 [submodule "wradlib"]
 	url = https://github.com/conda-forge/wradlib-feedstock.git
 	path = feedstocks/wradlib
+	branch = refs/heads/master
 [submodule "gdal"]
 	url = https://github.com/conda-forge/gdal-feedstock.git
 	path = feedstocks/gdal
+	branch = refs/heads/master
 [submodule "openjpeg"]
 	url = https://github.com/conda-forge/openjpeg-feedstock.git
 	path = feedstocks/openjpeg
+	branch = refs/heads/master
 [submodule "amqp"]
 	url = https://github.com/conda-forge/amqp-feedstock.git
 	path = feedstocks/amqp
+	branch = refs/heads/master
 [submodule "antlr"]
 	url = https://github.com/conda-forge/antlr-feedstock.git
 	path = feedstocks/antlr
+	branch = refs/heads/master
 [submodule "anyjson"]
 	url = https://github.com/conda-forge/anyjson-feedstock.git
 	path = feedstocks/anyjson
+	branch = refs/heads/master
 [submodule "autoconf"]
 	url = https://github.com/conda-forge/autoconf-feedstock.git
 	path = feedstocks/autoconf
+	branch = refs/heads/master
 [submodule "automake"]
 	url = https://github.com/conda-forge/automake-feedstock.git
 	path = feedstocks/automake
+	branch = refs/heads/master
 [submodule "billiard"]
 	url = https://github.com/conda-forge/billiard-feedstock.git
 	path = feedstocks/billiard
+	branch = refs/heads/master
 [submodule "celery"]
 	url = https://github.com/conda-forge/celery-feedstock.git
 	path = feedstocks/celery
+	branch = refs/heads/master
 [submodule "cyordereddict"]
 	url = https://github.com/conda-forge/cyordereddict-feedstock.git
 	path = feedstocks/cyordereddict
+	branch = refs/heads/master
 [submodule "expat"]
 	url = https://github.com/conda-forge/expat-feedstock.git
 	path = feedstocks/expat
+	branch = refs/heads/master
 [submodule "flower"]
 	url = https://github.com/conda-forge/flower-feedstock.git
 	path = feedstocks/flower
+	branch = refs/heads/master
 [submodule "gsl"]
 	url = https://github.com/conda-forge/gsl-feedstock.git
 	path = feedstocks/gsl
+	branch = refs/heads/master
 [submodule "hiredis"]
 	url = https://github.com/conda-forge/hiredis-feedstock.git
 	path = feedstocks/hiredis
+	branch = refs/heads/master
 [submodule "kombu"]
 	url = https://github.com/conda-forge/kombu-feedstock.git
 	path = feedstocks/kombu
+	branch = refs/heads/master
 [submodule "m4"]
 	url = https://github.com/conda-forge/m4-feedstock.git
 	path = feedstocks/m4
+	branch = refs/heads/master
 [submodule "nco"]
 	url = https://github.com/conda-forge/nco-feedstock.git
 	path = feedstocks/nco
+	branch = refs/heads/master
 [submodule "pandoc"]
 	url = https://github.com/conda-forge/pandoc-feedstock.git
 	path = feedstocks/pandoc
+	branch = refs/heads/master
 [submodule "pyinotify"]
 	url = https://github.com/conda-forge/pyinotify-feedstock.git
 	path = feedstocks/pyinotify
+	branch = refs/heads/master
 [submodule "pytest-cov"]
 	url = https://github.com/conda-forge/pytest-cov-feedstock.git
 	path = feedstocks/pytest-cov
+	branch = refs/heads/master
 [submodule "udunits2"]
 	url = https://github.com/conda-forge/udunits2-feedstock.git
 	path = feedstocks/udunits2
+	branch = refs/heads/master
 [submodule "cmake"]
 	url = https://github.com/conda-forge/cmake-feedstock.git
 	path = feedstocks/cmake
+	branch = refs/heads/master
 [submodule "fftw"]
 	url = https://github.com/conda-forge/fftw-feedstock.git
 	path = feedstocks/fftw
+	branch = refs/heads/master
 [submodule "g2clib"]
 	url = https://github.com/conda-forge/g2clib-feedstock.git
 	path = feedstocks/g2clib
+	branch = refs/heads/master
 [submodule "hdfeos2"]
 	url = https://github.com/conda-forge/hdfeos2-feedstock.git
 	path = feedstocks/hdfeos2
+	branch = refs/heads/master
 [submodule "hdfeos5"]
 	url = https://github.com/conda-forge/hdfeos5-feedstock.git
 	path = feedstocks/hdfeos5
+	branch = refs/heads/master
 [submodule "jasper"]
 	url = https://github.com/conda-forge/jasper-feedstock.git
 	path = feedstocks/jasper
+	branch = refs/heads/master
 [submodule "libiconv"]
 	url = https://github.com/conda-forge/libiconv-feedstock.git
 	path = feedstocks/libiconv
+	branch = refs/heads/master
 [submodule "pynio"]
 	url = https://github.com/conda-forge/pynio-feedstock.git
 	path = feedstocks/pynio
+	branch = refs/heads/master
 [submodule "pytest-runner"]
 	url = https://github.com/conda-forge/pytest-runner-feedstock.git
 	path = feedstocks/pytest-runner
+	branch = refs/heads/master
 [submodule "qimage2ndarray"]
 	url = https://github.com/conda-forge/qimage2ndarray-feedstock.git
 	path = feedstocks/qimage2ndarray
+	branch = refs/heads/master
 [submodule "perl"]
 	url = https://github.com/conda-forge/perl-feedstock.git
 	path = feedstocks/perl
+	branch = refs/heads/master
 [submodule "jq"]
 	url = https://github.com/conda-forge/jq-feedstock.git
 	path = feedstocks/jq
+	branch = refs/heads/master
 [submodule "libtool"]
 	url = https://github.com/conda-forge/libtool-feedstock.git
 	path = feedstocks/libtool
+	branch = refs/heads/master
 [submodule "oniguruma"]
 	url = https://github.com/conda-forge/oniguruma-feedstock.git
 	path = feedstocks/oniguruma
+	branch = refs/heads/master
 [submodule "pyfftw"]
 	url = https://github.com/conda-forge/pyfftw-feedstock.git
 	path = feedstocks/pyfftw
+	branch = refs/heads/master
 [submodule "esmf"]
 	url = https://github.com/conda-forge/esmf-feedstock.git
 	path = feedstocks/esmf
+	branch = refs/heads/master
 [submodule "esmpy"]
 	url = https://github.com/conda-forge/esmpy-feedstock.git
 	path = feedstocks/esmpy
+	branch = refs/heads/master
 [submodule "glances"]
 	url = https://github.com/conda-forge/glances-feedstock.git
 	path = feedstocks/glances
+	branch = refs/heads/master
 [submodule "mahotas"]
 	url = https://github.com/conda-forge/mahotas-feedstock.git
 	path = feedstocks/mahotas
+	branch = refs/heads/master
 [submodule "netcdf-fortran"]
 	url = https://github.com/conda-forge/netcdf-fortran-feedstock.git
 	path = feedstocks/netcdf-fortran
+	branch = refs/heads/master
 [submodule "pixman"]
 	url = https://github.com/conda-forge/pixman-feedstock.git
 	path = feedstocks/pixman
+	branch = refs/heads/master
 [submodule "pkg-config"]
 	url = https://github.com/conda-forge/pkg-config-feedstock.git
 	path = feedstocks/pkg-config
+	branch = refs/heads/master
 [submodule "pytest-mpl"]
 	url = https://github.com/conda-forge/pytest-mpl-feedstock.git
 	path = feedstocks/pytest-mpl
+	branch = refs/heads/master
 [submodule "h5netcdf"]
 	url = https://github.com/conda-forge/h5netcdf-feedstock.git
 	path = feedstocks/h5netcdf
+	branch = refs/heads/master
 [submodule "xarray"]
 	url = https://github.com/conda-forge/xarray-feedstock.git
 	path = feedstocks/xarray
+	branch = refs/heads/master
 [submodule "proj.4"]
 	url = https://github.com/conda-forge/proj.4-feedstock.git
 	path = feedstocks/proj.4
+	branch = refs/heads/master
 [submodule "cloudpickle"]
 	url = https://github.com/conda-forge/cloudpickle-feedstock.git
 	path = feedstocks/cloudpickle
+	branch = refs/heads/master
 [submodule "freeimage"]
 	url = https://github.com/conda-forge/freeimage-feedstock.git
 	path = feedstocks/freeimage
+	branch = refs/heads/master
 [submodule "webcolors"]
 	url = https://github.com/conda-forge/webcolors-feedstock.git
 	path = feedstocks/webcolors
+	branch = refs/heads/master
 [submodule "ncurses"]
 	url = https://github.com/conda-forge/ncurses-feedstock.git
 	path = feedstocks/ncurses
+	branch = refs/heads/master
 [submodule "runipy"]
 	url = https://github.com/conda-forge/runipy-feedstock.git
 	path = feedstocks/runipy
+	branch = refs/heads/master
 [submodule "splauncher"]
 	url = https://github.com/conda-forge/splauncher-feedstock.git
 	path = feedstocks/splauncher
+	branch = refs/heads/master
 [submodule "click-plugins"]
 	url = https://github.com/conda-forge/click-plugins-feedstock.git
 	path = feedstocks/click-plugins
+	branch = refs/heads/master
 [submodule "descartes"]
 	url = https://github.com/conda-forge/descartes-feedstock.git
 	path = feedstocks/descartes
+	branch = refs/heads/master
 [submodule "fiona"]
 	url = https://github.com/conda-forge/fiona-feedstock.git
 	path = feedstocks/fiona
+	branch = refs/heads/master
 [submodule "folium"]
 	url = https://github.com/conda-forge/folium-feedstock.git
 	path = feedstocks/folium
+	branch = refs/heads/master
 [submodule "geopandas"]
 	url = https://github.com/conda-forge/geopandas-feedstock.git
 	path = feedstocks/geopandas
+	branch = refs/heads/master
 [submodule "geopy"]
 	url = https://github.com/conda-forge/geopy-feedstock.git
 	path = feedstocks/geopy
+	branch = refs/heads/master
 [submodule "gflags"]
 	url = https://github.com/conda-forge/gflags-feedstock.git
 	path = feedstocks/gflags
+	branch = refs/heads/master
 [submodule "git"]
 	url = https://github.com/conda-forge/git-feedstock.git
 	path = feedstocks/git
+	branch = refs/heads/master
 [submodule "glog"]
 	url = https://github.com/conda-forge/glog-feedstock.git
 	path = feedstocks/glog
+	branch = refs/heads/master
 [submodule "leveldb"]
 	url = https://github.com/conda-forge/leveldb-feedstock.git
 	path = feedstocks/leveldb
+	branch = refs/heads/master
 [submodule "libspatialindex"]
 	url = https://github.com/conda-forge/libspatialindex-feedstock.git
 	path = feedstocks/libspatialindex
+	branch = refs/heads/master
 [submodule "munch"]
 	url = https://github.com/conda-forge/munch-feedstock.git
 	path = feedstocks/munch
+	branch = refs/heads/master
 [submodule "rtree"]
 	url = https://github.com/conda-forge/rtree-feedstock.git
 	path = feedstocks/rtree
+	branch = refs/heads/master
 [submodule "vincent"]
 	url = https://github.com/conda-forge/vincent-feedstock.git
 	path = feedstocks/vincent
+	branch = refs/heads/master
 [submodule "cdo"]
 	url = https://github.com/conda-forge/cdo-feedstock.git
 	path = feedstocks/cdo
+	branch = refs/heads/master
 [submodule "cf_units"]
 	url = https://github.com/conda-forge/cf_units-feedstock.git
 	path = feedstocks/cf_units
+	branch = refs/heads/master
 [submodule "ctd"]
 	url = https://github.com/conda-forge/ctd-feedstock.git
 	path = feedstocks/ctd
+	branch = refs/heads/master
 [submodule "gsw"]
 	url = https://github.com/conda-forge/gsw-feedstock.git
 	path = feedstocks/gsw
+	branch = refs/heads/master
 [submodule "libuuid"]
 	url = https://github.com/conda-forge/libuuid-feedstock.git
 	path = feedstocks/libuuid
+	branch = refs/heads/master
 [submodule "seawater"]
 	url = https://github.com/conda-forge/seawater-feedstock.git
 	path = feedstocks/seawater
+	branch = refs/heads/master
 [submodule "pynco"]
 	url = https://github.com/conda-forge/pynco-feedstock.git
 	path = feedstocks/pynco
+	branch = refs/heads/master
 [submodule "appdirs"]
 	url = https://github.com/conda-forge/appdirs-feedstock.git
 	path = feedstocks/appdirs
+	branch = refs/heads/master
 [submodule "freezegun"]
 	url = https://github.com/conda-forge/freezegun-feedstock.git
 	path = feedstocks/freezegun
+	branch = refs/heads/master
 [submodule "geojson"]
 	url = https://github.com/conda-forge/geojson-feedstock.git
 	path = feedstocks/geojson
+	branch = refs/heads/master
 [submodule "httpretty"]
 	url = https://github.com/conda-forge/httpretty-feedstock.git
 	path = feedstocks/httpretty
+	branch = refs/heads/master
 [submodule "isodate"]
 	url = https://github.com/conda-forge/isodate-feedstock.git
 	path = feedstocks/isodate
+	branch = refs/heads/master
 [submodule "suds-jurko"]
 	url = https://github.com/conda-forge/suds-jurko-feedstock.git
 	path = feedstocks/suds-jurko
+	branch = refs/heads/master
 [submodule "ulmo"]
 	url = https://github.com/conda-forge/ulmo-feedstock.git
 	path = feedstocks/ulmo
+	branch = refs/heads/master
 [submodule "codar2netcdf"]
 	url = https://github.com/conda-forge/codar2netcdf-feedstock.git
 	path = feedstocks/codar2netcdf
+	branch = refs/heads/master
 [submodule "epic2cf"]
 	url = https://github.com/conda-forge/epic2cf-feedstock.git
 	path = feedstocks/epic2cf
+	branch = refs/heads/master
 [submodule "flopy"]
 	url = https://github.com/conda-forge/flopy-feedstock.git
 	path = feedstocks/flopy
+	branch = refs/heads/master
 [submodule "modflow2netcdf"]
 	url = https://github.com/conda-forge/modflow2netcdf-feedstock.git
 	path = feedstocks/modflow2netcdf
+	branch = refs/heads/master
 [submodule "pyaxiom"]
 	url = https://github.com/conda-forge/pyaxiom-feedstock.git
 	path = feedstocks/pyaxiom
+	branch = refs/heads/master
 [submodule "pygc"]
 	url = https://github.com/conda-forge/pygc-feedstock.git
 	path = feedstocks/pygc
+	branch = refs/heads/master
 [submodule "pyncml"]
 	url = https://github.com/conda-forge/pyncml-feedstock.git
 	path = feedstocks/pyncml
+	branch = refs/heads/master
 [submodule "wera2netcdf"]
 	url = https://github.com/conda-forge/wera2netcdf-feedstock.git
 	path = feedstocks/wera2netcdf
+	branch = refs/heads/master
 [submodule "windrose"]
 	url = https://github.com/conda-forge/windrose-feedstock.git
 	path = feedstocks/windrose
+	branch = refs/heads/master
 [submodule "glpk"]
 	url = https://github.com/conda-forge/glpk-feedstock.git
 	path = feedstocks/glpk
+	branch = refs/heads/master
 [submodule "cartopy"]
 	url = https://github.com/conda-forge/cartopy-feedstock.git
 	path = feedstocks/cartopy
+	branch = refs/heads/master
 [submodule "owslib"]
 	url = https://github.com/conda-forge/owslib-feedstock.git
 	path = feedstocks/owslib
+	branch = refs/heads/master
 [submodule "pyepsg"]
 	url = https://github.com/conda-forge/pyepsg-feedstock.git
 	path = feedstocks/pyepsg
+	branch = refs/heads/master
 [submodule "pyshp"]
 	url = https://github.com/conda-forge/pyshp-feedstock.git
 	path = feedstocks/pyshp
+	branch = refs/heads/master
 [submodule "cc-plugin-glider"]
 	url = https://github.com/conda-forge/cc-plugin-glider-feedstock.git
 	path = feedstocks/cc-plugin-glider
+	branch = refs/heads/master
 [submodule "compliance-checker"]
 	url = https://github.com/conda-forge/compliance-checker-feedstock.git
 	path = feedstocks/compliance-checker
+	branch = refs/heads/master
 [submodule "lmdb"]
 	url = https://github.com/conda-forge/lmdb-feedstock.git
 	path = feedstocks/lmdb
+	branch = refs/heads/master
 [submodule "mox"]
 	url = https://github.com/conda-forge/mox-feedstock.git
 	path = feedstocks/mox
+	branch = refs/heads/master
 [submodule "petulant-bear"]
 	url = https://github.com/conda-forge/petulant-bear-feedstock.git
 	path = feedstocks/petulant-bear
+	branch = refs/heads/master
 [submodule "pygeoif"]
 	url = https://github.com/conda-forge/pygeoif-feedstock.git
 	path = feedstocks/pygeoif
+	branch = refs/heads/master
 [submodule "python-gflags"]
 	url = https://github.com/conda-forge/python-gflags-feedstock.git
 	path = feedstocks/python-gflags
+	branch = refs/heads/master
 [submodule "python-leveldb"]
 	url = https://github.com/conda-forge/python-leveldb-feedstock.git
 	path = feedstocks/python-leveldb
+	branch = refs/heads/master
 [submodule "wicken"]
 	url = https://github.com/conda-forge/wicken-feedstock.git
 	path = feedstocks/wicken
+	branch = refs/heads/master
 [submodule "google-apputils"]
 	url = https://github.com/conda-forge/google-apputils-feedstock.git
 	path = feedstocks/google-apputils
+	branch = refs/heads/master
 [submodule "auditwheel"]
 	url = https://github.com/conda-forge/auditwheel-feedstock.git
 	path = feedstocks/auditwheel
+	branch = refs/heads/master
 [submodule "csa"]
 	url = https://github.com/conda-forge/csa-feedstock.git
 	path = feedstocks/csa
+	branch = refs/heads/master
 [submodule "gridgen"]
 	url = https://github.com/conda-forge/gridgen-feedstock.git
 	path = feedstocks/gridgen
+	branch = refs/heads/master
 [submodule "gridutils"]
 	url = https://github.com/conda-forge/gridutils-feedstock.git
 	path = feedstocks/gridutils
+	branch = refs/heads/master
 [submodule "nn"]
 	url = https://github.com/conda-forge/nn-feedstock.git
 	path = feedstocks/nn
+	branch = refs/heads/master
 [submodule "pyelftools"]
 	url = https://github.com/conda-forge/pyelftools-feedstock.git
 	path = feedstocks/pyelftools
+	branch = refs/heads/master
 [submodule "pygridgen"]
 	url = https://github.com/conda-forge/pygridgen-feedstock.git
 	path = feedstocks/pygridgen
+	branch = refs/heads/master
 [submodule "pygridtools"]
 	url = https://github.com/conda-forge/pygridtools-feedstock.git
 	path = feedstocks/pygridtools
+	branch = refs/heads/master
 [submodule "rank_filter"]
 	url = https://github.com/conda-forge/rank_filter-feedstock.git
 	path = feedstocks/rank_filter
+	branch = refs/heads/master
 [submodule "typing"]
 	url = https://github.com/conda-forge/typing-feedstock.git
 	path = feedstocks/typing
+	branch = refs/heads/master
 [submodule "python-cdo"]
 	url = https://github.com/conda-forge/python-cdo-feedstock.git
 	path = feedstocks/python-cdo
+	branch = refs/heads/master
 [submodule "django-celery"]
 	url = https://github.com/conda-forge/django-celery-feedstock.git
 	path = feedstocks/django-celery
+	branch = refs/heads/master
 [submodule "django"]
 	url = https://github.com/conda-forge/django-feedstock.git
 	path = feedstocks/django
+	branch = refs/heads/master
 [submodule "django-nested-inline"]
 	url = https://github.com/conda-forge/django-nested-inline-feedstock.git
 	path = feedstocks/django-nested-inline
+	branch = refs/heads/master
 [submodule "django-redis-cache"]
 	url = https://github.com/conda-forge/django-redis-cache-feedstock.git
 	path = feedstocks/django-redis-cache
+	branch = refs/heads/master
 [submodule "django-taggit"]
 	url = https://github.com/conda-forge/django-taggit-feedstock.git
 	path = feedstocks/django-taggit
+	branch = refs/heads/master
 [submodule "boost"]
 	url = https://github.com/conda-forge/boost-feedstock.git
 	path = feedstocks/boost
+	branch = refs/heads/master
 [submodule "hdf5"]
 	url = https://github.com/conda-forge/hdf5-feedstock.git
 	path = feedstocks/hdf5
+	branch = refs/heads/master
 [submodule "basemap-data-hires"]
 	url = https://github.com/conda-forge/basemap-data-hires-feedstock.git
 	path = feedstocks/basemap-data-hires
+	branch = refs/heads/master
 [submodule "basemap"]
 	url = https://github.com/conda-forge/basemap-feedstock.git
 	path = feedstocks/basemap
+	branch = refs/heads/master
 [submodule "h5py"]
 	url = https://github.com/conda-forge/h5py-feedstock.git
 	path = feedstocks/h5py
+	branch = refs/heads/master
 [submodule "icu"]
 	url = https://github.com/conda-forge/icu-feedstock.git
 	path = feedstocks/icu
+	branch = refs/heads/master
 [submodule "giflib"]
 	url = https://github.com/conda-forge/giflib-feedstock.git
 	path = feedstocks/giflib
+	branch = refs/heads/master
 [submodule "gmp"]
 	url = https://github.com/conda-forge/gmp-feedstock.git
 	path = feedstocks/gmp
+	branch = refs/heads/master
 [submodule "mpfr"]
 	url = https://github.com/conda-forge/mpfr-feedstock.git
 	path = feedstocks/mpfr
+	branch = refs/heads/master
 [submodule "mpc"]
 	url = https://github.com/conda-forge/mpc-feedstock.git
 	path = feedstocks/mpc
+	branch = refs/heads/master
 [submodule "vigra"]
 	url = https://github.com/conda-forge/vigra-feedstock.git
 	path = feedstocks/vigra
+	branch = refs/heads/master
 [submodule "mpir"]
 	url = https://github.com/conda-forge/mpir-feedstock.git
 	path = feedstocks/mpir
+	branch = refs/heads/master
 [submodule "yasm"]
 	url = https://github.com/conda-forge/yasm-feedstock.git
 	path = feedstocks/yasm
+	branch = refs/heads/master
 [submodule "x264"]
 	url = https://github.com/conda-forge/x264-feedstock.git
 	path = feedstocks/x264
+	branch = refs/heads/master
 [submodule "flann"]
 	url = https://github.com/conda-forge/flann-feedstock.git
 	path = feedstocks/flann
+	branch = refs/heads/master
 [submodule "pyflann"]
 	url = https://github.com/conda-forge/pyflann-feedstock.git
 	path = feedstocks/pyflann
+	branch = refs/heads/master
 [submodule "affine"]
 	path = feedstocks/affine
 	url = https://github.com/conda-forge/affine-feedstock.git
+	branch = refs/heads/master
 [submodule "check"]
 	path = feedstocks/check
 	url = https://github.com/conda-forge/check-feedstock.git
+	branch = refs/heads/master
 [submodule "rasterio"]
 	path = feedstocks/rasterio
 	url = https://github.com/conda-forge/rasterio-feedstock.git
+	branch = refs/heads/master
 [submodule "texinfo"]
 	path = feedstocks/texinfo
 	url = https://github.com/conda-forge/texinfo-feedstock.git
+	branch = refs/heads/master
 [submodule "yt"]
 	path = feedstocks/yt
 	url = https://github.com/conda-forge/yt-feedstock.git
+	branch = refs/heads/master
 [submodule "dj-static"]
 	path = feedstocks/dj-static
 	url = https://github.com/conda-forge/dj-static-feedstock.git
+	branch = refs/heads/master
 [submodule "libblitz"]
 	path = feedstocks/libblitz
 	url = https://github.com/conda-forge/libblitz-feedstock.git
+	branch = refs/heads/master
 [submodule "pystache"]
 	path = feedstocks/pystache
 	url = https://github.com/conda-forge/pystache-feedstock.git
+	branch = refs/heads/master
 [submodule "static"]
 	path = feedstocks/static
 	url = https://github.com/conda-forge/static-feedstock.git
+	branch = refs/heads/master
 [submodule "flex"]
 	path = feedstocks/flex
 	url = https://github.com/conda-forge/flex-feedstock.git
+	branch = refs/heads/master
 [submodule "bison"]
 	path = feedstocks/bison
 	url = https://github.com/conda-forge/bison-feedstock.git
+	branch = refs/heads/master
 [submodule "libmatio"]
 	path = feedstocks/libmatio
 	url = https://github.com/conda-forge/libmatio-feedstock.git
+	branch = refs/heads/master
 [submodule "netcdf-cxx4"]
 	path = feedstocks/netcdf-cxx4
 	url = https://github.com/conda-forge/netcdf-cxx4-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-benchmark"]
 	path = feedstocks/pytest-benchmark
 	url = https://github.com/conda-forge/pytest-benchmark-feedstock.git
+	branch = refs/heads/master
 [submodule "sox"]
 	path = feedstocks/sox
 	url = https://github.com/conda-forge/sox-feedstock.git
+	branch = refs/heads/master
 [submodule "libunistring"]
 	path = feedstocks/libunistring
 	url = https://github.com/conda-forge/libunistring-feedstock.git
+	branch = refs/heads/master
 [submodule "libffi"]
 	path = feedstocks/libffi
 	url = https://github.com/conda-forge/libffi-feedstock.git
+	branch = refs/heads/master
 [submodule "libmo_unpack"]
 	path = feedstocks/libmo_unpack
 	url = https://github.com/conda-forge/libmo_unpack-feedstock.git
+	branch = refs/heads/master
 [submodule "libatomic_ops"]
 	path = feedstocks/libatomic_ops
 	url = https://github.com/conda-forge/libatomic_ops-feedstock.git
+	branch = refs/heads/master
 [submodule "bdw-gc"]
 	path = feedstocks/bdw-gc
 	url = https://github.com/conda-forge/bdw-gc-feedstock.git
+	branch = refs/heads/master
 [submodule "json-c"]
 	path = feedstocks/json-c
 	url = https://github.com/conda-forge/json-c-feedstock.git
+	branch = refs/heads/master
 [submodule "awesome-slugify"]
 	path = feedstocks/awesome-slugify
 	url = https://github.com/conda-forge/awesome-slugify-feedstock.git
+	branch = refs/heads/master
 [submodule "django-autoslug"]
 	path = feedstocks/django-autoslug
 	url = https://github.com/conda-forge/django-autoslug-feedstock.git
+	branch = refs/heads/master
 [submodule "django-debug-toolbar"]
 	path = feedstocks/django-debug-toolbar
 	url = https://github.com/conda-forge/django-debug-toolbar-feedstock.git
+	branch = refs/heads/master
 [submodule "django-extensions"]
 	path = feedstocks/django-extensions
 	url = https://github.com/conda-forge/django-extensions-feedstock.git
+	branch = refs/heads/master
 [submodule "django-grappelli"]
 	path = feedstocks/django-grappelli
 	url = https://github.com/conda-forge/django-grappelli-feedstock.git
+	branch = refs/heads/master
 [submodule "django-typed-models"]
 	path = feedstocks/django-typed-models
 	url = https://github.com/conda-forge/django-typed-models-feedstock.git
+	branch = refs/heads/master
 [submodule "djangorestframework"]
 	path = feedstocks/djangorestframework
 	url = https://github.com/conda-forge/djangorestframework-feedstock.git
+	branch = refs/heads/master
 [submodule "luigi"]
 	path = feedstocks/luigi
 	url = https://github.com/conda-forge/luigi-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-django"]
 	path = feedstocks/pytest-django
 	url = https://github.com/conda-forge/pytest-django-feedstock.git
+	branch = refs/heads/master
 [submodule "regex"]
 	path = feedstocks/regex
 	url = https://github.com/conda-forge/regex-feedstock.git
+	branch = refs/heads/master
 [submodule "requests-toolbelt"]
 	path = feedstocks/requests-toolbelt
 	url = https://github.com/conda-forge/requests-toolbelt-feedstock.git
+	branch = refs/heads/master
 [submodule "setuptools_scm"]
 	path = feedstocks/setuptools_scm
 	url = https://github.com/conda-forge/setuptools_scm-feedstock.git
+	branch = refs/heads/master
 [submodule "eigen"]
 	path = feedstocks/eigen
 	url = https://github.com/conda-forge/eigen-feedstock.git
+	branch = refs/heads/master
 [submodule "django_polymorphic"]
 	path = feedstocks/django_polymorphic
 	url = https://github.com/conda-forge/django_polymorphic-feedstock.git
+	branch = refs/heads/master
 [submodule "opencv"]
 	path = feedstocks/opencv
 	url = https://github.com/conda-forge/opencv-feedstock.git
+	branch = refs/heads/master
 [submodule "freexl"]
 	path = feedstocks/freexl
 	url = https://github.com/conda-forge/freexl-feedstock.git
+	branch = refs/heads/master
 [submodule "jplephem"]
 	path = feedstocks/jplephem
 	url = https://github.com/conda-forge/jplephem-feedstock.git
+	branch = refs/heads/master
 [submodule "poliastro"]
 	path = feedstocks/poliastro
 	url = https://github.com/conda-forge/poliastro-feedstock.git
+	branch = refs/heads/master
 [submodule "haversine"]
 	path = feedstocks/haversine
 	url = https://github.com/conda-forge/haversine-feedstock.git
+	branch = refs/heads/master
 [submodule "libsodium"]
 	path = feedstocks/libsodium
 	url = https://github.com/conda-forge/libsodium-feedstock.git
+	branch = refs/heads/master
 [submodule "zeromq"]
 	path = feedstocks/zeromq
 	url = https://github.com/conda-forge/zeromq-feedstock.git
+	branch = refs/heads/master
 [submodule "ffmpeg"]
 	path = feedstocks/ffmpeg
 	url = https://github.com/conda-forge/ffmpeg-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.extension"]
 	path = feedstocks/bob.extension
 	url = https://github.com/conda-forge/bob.extension-feedstock.git
+	branch = refs/heads/master
 [submodule "c99-to-c89"]
 	path = feedstocks/c99-to-c89
 	url = https://github.com/conda-forge/c99-to-c89-feedstock.git
+	branch = refs/heads/master
 [submodule "biggus"]
 	path = feedstocks/biggus
 	url = https://github.com/conda-forge/biggus-feedstock.git
+	branch = refs/heads/master
 [submodule "ecmwf_grib"]
 	path = feedstocks/ecmwf_grib
 	url = https://github.com/conda-forge/ecmwf_grib-feedstock.git
+	branch = refs/heads/master
 [submodule "pyke"]
 	path = feedstocks/pyke
 	url = https://github.com/conda-forge/pyke-feedstock.git
+	branch = refs/heads/master
 [submodule "libxml2"]
 	path = feedstocks/libxml2
 	url = https://github.com/conda-forge/libxml2-feedstock.git
+	branch = refs/heads/master
 [submodule "pyamg"]
 	path = feedstocks/pyamg
 	url = https://github.com/conda-forge/pyamg-feedstock.git
+	branch = refs/heads/master
 [submodule "nuitka"]
 	path = feedstocks/nuitka
 	url = https://github.com/conda-forge/nuitka-feedstock.git
+	branch = refs/heads/master
 [submodule "libspatialite"]
 	path = feedstocks/libspatialite
 	url = https://github.com/conda-forge/libspatialite-feedstock.git
+	branch = refs/heads/master
 [submodule "megaman"]
 	path = feedstocks/megaman
 	url = https://github.com/conda-forge/megaman-feedstock.git
+	branch = refs/heads/master
 [submodule "caffe"]
 	path = feedstocks/caffe
 	url = https://github.com/conda-forge/caffe-feedstock.git
+	branch = refs/heads/master
 [submodule "snuggs"]
 	path = feedstocks/snuggs
 	url = https://github.com/conda-forge/snuggs-feedstock.git
+	branch = refs/heads/master
 [submodule "primesieve"]
 	path = feedstocks/primesieve
 	url = https://github.com/conda-forge/primesieve-feedstock.git
+	branch = refs/heads/master
 [submodule "python-primesieve"]
 	path = feedstocks/python-primesieve
 	url = https://github.com/conda-forge/python-primesieve-feedstock.git
+	branch = refs/heads/master
 [submodule "ipython"]
 	path = feedstocks/ipython
 	url = https://github.com/conda-forge/ipython-feedstock.git
+	branch = refs/heads/master
 [submodule "cmt"]
 	path = feedstocks/cmt
 	url = https://github.com/conda-forge/cmt-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.blitz"]
 	path = feedstocks/bob.blitz
 	url = https://github.com/conda-forge/bob.blitz-feedstock.git
+	branch = refs/heads/master
 [submodule "mpld3"]
 	path = feedstocks/mpld3
 	url = https://github.com/conda-forge/mpld3-feedstock.git
+	branch = refs/heads/master
 [submodule "mplexporter"]
 	path = feedstocks/mplexporter
 	url = https://github.com/conda-forge/mplexporter-feedstock.git
+	branch = refs/heads/master
 [submodule "mplleaflet"]
 	path = feedstocks/mplleaflet
 	url = https://github.com/conda-forge/mplleaflet-feedstock.git
+	branch = refs/heads/master
 [submodule "pydicom"]
 	path = feedstocks/pydicom
 	url = https://github.com/conda-forge/pydicom-feedstock.git
+	branch = refs/heads/master
 [submodule "nodejs"]
 	path = feedstocks/nodejs
 	url = https://github.com/conda-forge/nodejs-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_core"]
 	path = feedstocks/jupyter_core
 	url = https://github.com/conda-forge/jupyter_core-feedstock.git
+	branch = refs/heads/master
 [submodule "notebook"]
 	path = feedstocks/notebook
 	url = https://github.com/conda-forge/notebook-feedstock.git
+	branch = refs/heads/master
 [submodule "ipykernel"]
 	path = feedstocks/ipykernel
 	url = https://github.com/conda-forge/ipykernel-feedstock.git
+	branch = refs/heads/master
 [submodule "nbconvert"]
 	path = feedstocks/nbconvert
 	url = https://github.com/conda-forge/nbconvert-feedstock.git
+	branch = refs/heads/master
 [submodule "babel"]
 	path = feedstocks/babel
 	url = https://github.com/conda-forge/babel-feedstock.git
+	branch = refs/heads/master
 [submodule "pywebhdfs"]
 	path = feedstocks/pywebhdfs
 	url = https://github.com/conda-forge/pywebhdfs-feedstock.git
+	branch = refs/heads/master
 [submodule "colorlog"]
 	path = feedstocks/colorlog
 	url = https://github.com/conda-forge/colorlog-feedstock.git
+	branch = refs/heads/master
 [submodule "ninja"]
 	path = feedstocks/ninja
 	url = https://github.com/conda-forge/ninja-feedstock.git
+	branch = refs/heads/master
 [submodule "configparser"]
 	path = feedstocks/configparser
 	url = https://github.com/conda-forge/configparser-feedstock.git
+	branch = refs/heads/master
 [submodule "entrypoints"]
 	path = feedstocks/entrypoints
 	url = https://github.com/conda-forge/entrypoints-feedstock.git
+	branch = refs/heads/master
 [submodule "valideer"]
 	path = feedstocks/valideer
 	url = https://github.com/conda-forge/valideer-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.core"]
 	path = feedstocks/bob.core
 	url = https://github.com/conda-forge/bob.core-feedstock.git
+	branch = refs/heads/master
 [submodule "binutils"]
 	path = feedstocks/binutils
 	url = https://github.com/conda-forge/binutils-feedstock.git
+	branch = refs/heads/master
 [submodule "spyne"]
 	path = feedstocks/spyne
 	url = https://github.com/conda-forge/spyne-feedstock.git
+	branch = refs/heads/master
 [submodule "betamax"]
 	path = feedstocks/betamax
 	url = https://github.com/conda-forge/betamax-feedstock.git
+	branch = refs/heads/master
 [submodule "betamax-matchers"]
 	path = feedstocks/betamax-matchers
 	url = https://github.com/conda-forge/betamax-matchers-feedstock.git
+	branch = refs/heads/master
 [submodule "geojsonio"]
 	path = feedstocks/geojsonio
 	url = https://github.com/conda-forge/geojsonio-feedstock.git
+	branch = refs/heads/master
 [submodule "geolinks"]
 	path = feedstocks/geolinks
 	url = https://github.com/conda-forge/geolinks-feedstock.git
+	branch = refs/heads/master
 [submodule "github3.py"]
 	path = feedstocks/github3.py
 	url = https://github.com/conda-forge/github3.py-feedstock.git
+	branch = refs/heads/master
 [submodule "paegan"]
 	path = feedstocks/paegan
 	url = https://github.com/conda-forge/paegan-feedstock.git
+	branch = refs/heads/master
 [submodule "palettable"]
 	path = feedstocks/palettable
 	url = https://github.com/conda-forge/palettable-feedstock.git
+	branch = refs/heads/master
 [submodule "pycsw"]
 	path = feedstocks/pycsw
 	url = https://github.com/conda-forge/pycsw-feedstock.git
+	branch = refs/heads/master
 [submodule "pyoos"]
 	path = feedstocks/pyoos
 	url = https://github.com/conda-forge/pyoos-feedstock.git
+	branch = refs/heads/master
 [submodule "uritemplate.py"]
 	path = feedstocks/uritemplate.py
 	url = https://github.com/conda-forge/uritemplate.py-feedstock.git
+	branch = refs/heads/master
 [submodule "yaml2ncml"]
 	path = feedstocks/yaml2ncml
 	url = https://github.com/conda-forge/yaml2ncml-feedstock.git
+	branch = refs/heads/master
 [submodule "pyzmq"]
 	path = feedstocks/pyzmq
 	url = https://github.com/conda-forge/pyzmq-feedstock.git
+	branch = refs/heads/master
 [submodule "blinker"]
 	path = feedstocks/blinker
 	url = https://github.com/conda-forge/blinker-feedstock.git
+	branch = refs/heads/master
 [submodule "feedgenerator"]
 	path = feedstocks/feedgenerator
 	url = https://github.com/conda-forge/feedgenerator-feedstock.git
+	branch = refs/heads/master
 [submodule "ghp-import"]
 	path = feedstocks/ghp-import
 	url = https://github.com/conda-forge/ghp-import-feedstock.git
+	branch = refs/heads/master
 [submodule "pelican"]
 	path = feedstocks/pelican
 	url = https://github.com/conda-forge/pelican-feedstock.git
+	branch = refs/heads/master
 [submodule "mistune"]
 	path = feedstocks/mistune
 	url = https://github.com/conda-forge/mistune-feedstock.git
+	branch = refs/heads/master
 [submodule "traitlets"]
 	path = feedstocks/traitlets
 	url = https://github.com/conda-forge/traitlets-feedstock.git
+	branch = refs/heads/master
 [submodule "dateutils"]
 	path = feedstocks/dateutils
 	url = https://github.com/conda-forge/dateutils-feedstock.git
+	branch = refs/heads/master
 [submodule "urwid"]
 	path = feedstocks/urwid
 	url = https://github.com/conda-forge/urwid-feedstock.git
+	branch = refs/heads/master
 [submodule "terminado"]
 	path = feedstocks/terminado
 	url = https://github.com/conda-forge/terminado-feedstock.git
+	branch = refs/heads/master
 [submodule "xo"]
 	path = feedstocks/xo
 	url = https://github.com/conda-forge/xo-feedstock.git
+	branch = refs/heads/master
 [submodule "markupsafe"]
 	path = feedstocks/markupsafe
 	url = https://github.com/conda-forge/markupsafe-feedstock.git
+	branch = refs/heads/master
 [submodule "pygments"]
 	path = feedstocks/pygments
 	url = https://github.com/conda-forge/pygments-feedstock.git
+	branch = refs/heads/master
 [submodule "certifi"]
 	path = feedstocks/certifi
 	url = https://github.com/conda-forge/certifi-feedstock.git
+	branch = refs/heads/master
 [submodule "ssl_match_hostname"]
 	path = feedstocks/ssl_match_hostname
 	url = https://github.com/conda-forge/ssl_match_hostname-feedstock.git
+	branch = refs/heads/master
 [submodule "tornado"]
 	path = feedstocks/tornado
 	url = https://github.com/conda-forge/tornado-feedstock.git
+	branch = refs/heads/master
 [submodule "cell_tree2d"]
 	path = feedstocks/cell_tree2d
 	url = https://github.com/conda-forge/cell_tree2d-feedstock.git
+	branch = refs/heads/master
 [submodule "ciso"]
 	path = feedstocks/ciso
 	url = https://github.com/conda-forge/ciso-feedstock.git
+	branch = refs/heads/master
 [submodule "ioos_qartod"]
 	path = feedstocks/ioos_qartod
 	url = https://github.com/conda-forge/ioos_qartod-feedstock.git
+	branch = refs/heads/master
 [submodule "paegan-transport"]
 	path = feedstocks/paegan-transport
 	url = https://github.com/conda-forge/paegan-transport-feedstock.git
+	branch = refs/heads/master
 [submodule "pysgrid"]
 	path = feedstocks/pysgrid
 	url = https://github.com/conda-forge/pysgrid-feedstock.git
+	branch = refs/heads/master
 [submodule "pyugrid"]
 	path = feedstocks/pyugrid
 	url = https://github.com/conda-forge/pyugrid-feedstock.git
+	branch = refs/heads/master
 [submodule "quantities"]
 	path = feedstocks/quantities
 	url = https://github.com/conda-forge/quantities-feedstock.git
+	branch = refs/heads/master
 [submodule "thredds_crawler"]
 	path = feedstocks/thredds_crawler
 	url = https://github.com/conda-forge/thredds_crawler-feedstock.git
+	branch = refs/heads/master
 [submodule "eofs"]
 	path = feedstocks/eofs
 	url = https://github.com/conda-forge/eofs-feedstock.git
+	branch = refs/heads/master
 [submodule "gridfill"]
 	path = feedstocks/gridfill
 	url = https://github.com/conda-forge/gridfill-feedstock.git
+	branch = refs/heads/master
 [submodule "pyspharm"]
 	path = feedstocks/pyspharm
 	url = https://github.com/conda-forge/pyspharm-feedstock.git
+	branch = refs/heads/master
 [submodule "windspharm"]
 	path = feedstocks/windspharm
 	url = https://github.com/conda-forge/windspharm-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.io.base"]
 	path = feedstocks/bob.io.base
 	url = https://github.com/conda-forge/bob.io.base-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.math"]
 	path = feedstocks/bob.math
 	url = https://github.com/conda-forge/bob.math-feedstock.git
+	branch = refs/heads/master
 [submodule "pexpect"]
 	path = feedstocks/pexpect
 	url = https://github.com/conda-forge/pexpect-feedstock.git
+	branch = refs/heads/master
 [submodule "ptyprocess"]
 	path = feedstocks/ptyprocess
 	url = https://github.com/conda-forge/ptyprocess-feedstock.git
+	branch = refs/heads/master
 [submodule "python-drmaa"]
 	path = feedstocks/python-drmaa
 	url = https://github.com/conda-forge/python-drmaa-feedstock.git
+	branch = refs/heads/master
 [submodule "pickleshare"]
 	path = feedstocks/pickleshare
 	url = https://github.com/conda-forge/pickleshare-feedstock.git
+	branch = refs/heads/master
 [submodule "fortran-magic"]
 	path = feedstocks/fortran-magic
 	url = https://github.com/conda-forge/fortran-magic-feedstock.git
+	branch = refs/heads/master
 [submodule "metakernel"]
 	path = feedstocks/metakernel
 	url = https://github.com/conda-forge/metakernel-feedstock.git
+	branch = refs/heads/master
 [submodule "oct2py"]
 	path = feedstocks/oct2py
 	url = https://github.com/conda-forge/oct2py-feedstock.git
+	branch = refs/heads/master
 [submodule "pymatbridge"]
 	path = feedstocks/pymatbridge
 	url = https://github.com/conda-forge/pymatbridge-feedstock.git
+	branch = refs/heads/master
 [submodule "pyopengl"]
 	path = feedstocks/pyopengl
 	url = https://github.com/conda-forge/pyopengl-feedstock.git
+	branch = refs/heads/master
 [submodule "livereload"]
 	path = feedstocks/livereload
 	url = https://github.com/conda-forge/livereload-feedstock.git
+	branch = refs/heads/master
 [submodule "mkdocs-bootstrap"]
 	path = feedstocks/mkdocs-bootstrap
 	url = https://github.com/conda-forge/mkdocs-bootstrap-feedstock.git
+	branch = refs/heads/master
 [submodule "mkdocs-bootswatch"]
 	path = feedstocks/mkdocs-bootswatch
 	url = https://github.com/conda-forge/mkdocs-bootswatch-feedstock.git
+	branch = refs/heads/master
 [submodule "mkdocs"]
 	path = feedstocks/mkdocs
 	url = https://github.com/conda-forge/mkdocs-feedstock.git
+	branch = refs/heads/master
 [submodule "pyutilib"]
 	path = feedstocks/pyutilib
 	url = https://github.com/conda-forge/pyutilib-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.io.matlab"]
 	path = feedstocks/bob.io.matlab
 	url = https://github.com/conda-forge/bob.io.matlab-feedstock.git
+	branch = refs/heads/master
 [submodule "ckanapi"]
 	path = feedstocks/ckanapi
 	url = https://github.com/conda-forge/ckanapi-feedstock.git
+	branch = refs/heads/master
 [submodule "docopt"]
 	path = feedstocks/docopt
 	url = https://github.com/conda-forge/docopt-feedstock.git
+	branch = refs/heads/master
 [submodule "gpxpy"]
 	path = feedstocks/gpxpy
 	url = https://github.com/conda-forge/gpxpy-feedstock.git
+	branch = refs/heads/master
 [submodule "gridgeo"]
 	path = feedstocks/gridgeo
 	url = https://github.com/conda-forge/gridgeo-feedstock.git
+	branch = refs/heads/master
 [submodule "pygeogrids"]
 	path = feedstocks/pygeogrids
 	url = https://github.com/conda-forge/pygeogrids-feedstock.git
+	branch = refs/heads/master
 [submodule "pykdtree"]
 	path = feedstocks/pykdtree
 	url = https://github.com/conda-forge/pykdtree-feedstock.git
+	branch = refs/heads/master
 [submodule "pykml"]
 	path = feedstocks/pykml
 	url = https://github.com/conda-forge/pykml-feedstock.git
+	branch = refs/heads/master
 [submodule "pyresample"]
 	path = feedstocks/pyresample
 	url = https://github.com/conda-forge/pyresample-feedstock.git
+	branch = refs/heads/master
 [submodule "pyscaffold"]
 	path = feedstocks/pyscaffold
 	url = https://github.com/conda-forge/pyscaffold-feedstock.git
+	branch = refs/heads/master
 [submodule "simplekml"]
 	path = feedstocks/simplekml
 	url = https://github.com/conda-forge/simplekml-feedstock.git
+	branch = refs/heads/master
 [submodule "genshi"]
 	path = feedstocks/genshi
 	url = https://github.com/conda-forge/genshi-feedstock.git
+	branch = refs/heads/master
 [submodule "httplib2"]
 	path = feedstocks/httplib2
 	url = https://github.com/conda-forge/httplib2-feedstock.git
+	branch = refs/heads/master
 [submodule "pastescript"]
 	path = feedstocks/pastescript
 	url = https://github.com/conda-forge/pastescript-feedstock.git
+	branch = refs/heads/master
 [submodule "pydap"]
 	path = feedstocks/pydap
 	url = https://github.com/conda-forge/pydap-feedstock.git
+	branch = refs/heads/master
 [submodule "patchelf"]
 	path = feedstocks/patchelf
 	url = https://github.com/conda-forge/patchelf-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.io.audio"]
 	path = feedstocks/bob.io.audio
 	url = https://github.com/conda-forge/bob.io.audio-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.io.image"]
 	path = feedstocks/bob.io.image
 	url = https://github.com/conda-forge/bob.io.image-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.io.video"]
 	path = feedstocks/bob.io.video
 	url = https://github.com/conda-forge/bob.io.video-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.learn.activation"]
 	path = feedstocks/bob.learn.activation
 	url = https://github.com/conda-forge/bob.learn.activation-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.measure"]
 	path = feedstocks/bob.measure
 	url = https://github.com/conda-forge/bob.measure-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.sp"]
 	path = feedstocks/bob.sp
 	url = https://github.com/conda-forge/bob.sp-feedstock.git
+	branch = refs/heads/master
 [submodule "ipywidgets"]
 	path = feedstocks/ipywidgets
 	url = https://github.com/conda-forge/ipywidgets-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_client"]
 	path = feedstocks/jupyter_client
 	url = https://github.com/conda-forge/jupyter_client-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_console"]
 	path = feedstocks/jupyter_console
 	url = https://github.com/conda-forge/jupyter_console-feedstock.git
+	branch = refs/heads/master
 [submodule "nbformat"]
 	path = feedstocks/nbformat
 	url = https://github.com/conda-forge/nbformat-feedstock.git
+	branch = refs/heads/master
 [submodule "ibis-framework"]
 	path = feedstocks/ibis-framework
 	url = https://github.com/conda-forge/ibis-framework-feedstock.git
+	branch = refs/heads/master
 [submodule "impyla"]
 	path = feedstocks/impyla
 	url = https://github.com/conda-forge/impyla-feedstock.git
+	branch = refs/heads/master
 [submodule "python-hdfs"]
 	path = feedstocks/python-hdfs
 	url = https://github.com/conda-forge/python-hdfs-feedstock.git
+	branch = refs/heads/master
 [submodule "thrift"]
 	path = feedstocks/thrift
 	url = https://github.com/conda-forge/thrift-feedstock.git
+	branch = refs/heads/master
 [submodule "thriftpy"]
 	path = feedstocks/thriftpy
 	url = https://github.com/conda-forge/thriftpy-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ap"]
 	path = feedstocks/bob.ap
 	url = https://github.com/conda-forge/bob.ap-feedstock.git
+	branch = refs/heads/master
 [submodule "libsvm"]
 	path = feedstocks/libsvm
 	url = https://github.com/conda-forge/libsvm-feedstock.git
+	branch = refs/heads/master
 [submodule "zlib"]
 	path = feedstocks/zlib
 	url = https://github.com/conda-forge/zlib-feedstock.git
+	branch = refs/heads/master
 [submodule "jpeg"]
 	path = feedstocks/jpeg
 	url = https://github.com/conda-forge/jpeg-feedstock.git
+	branch = refs/heads/master
 [submodule "pygrib"]
 	path = feedstocks/pygrib
 	url = https://github.com/conda-forge/pygrib-feedstock.git
+	branch = refs/heads/master
 [submodule "hdf4"]
 	path = feedstocks/hdf4
 	url = https://github.com/conda-forge/hdf4-feedstock.git
+	branch = refs/heads/master
 [submodule "nitime"]
 	path = feedstocks/nitime
 	url = https://github.com/conda-forge/nitime-feedstock.git
+	branch = refs/heads/master
 [submodule "oceans"]
 	path = feedstocks/oceans
 	url = https://github.com/conda-forge/oceans-feedstock.git
+	branch = refs/heads/master
 [submodule "pygdp"]
 	path = feedstocks/pygdp
 	url = https://github.com/conda-forge/pygdp-feedstock.git
+	branch = refs/heads/master
 [submodule "pyhdf"]
 	path = feedstocks/pyhdf
 	url = https://github.com/conda-forge/pyhdf-feedstock.git
+	branch = refs/heads/master
 [submodule "pyhum"]
 	path = feedstocks/pyhum
 	url = https://github.com/conda-forge/pyhum-feedstock.git
+	branch = refs/heads/master
 [submodule "pyseidon"]
 	path = feedstocks/pyseidon
 	url = https://github.com/conda-forge/pyseidon-feedstock.git
+	branch = refs/heads/master
 [submodule "python-ternary"]
 	path = feedstocks/python-ternary
 	url = https://github.com/conda-forge/python-ternary-feedstock.git
+	branch = refs/heads/master
 [submodule "pywavelets"]
 	path = feedstocks/pywavelets
 	url = https://github.com/conda-forge/pywavelets-feedstock.git
+	branch = refs/heads/master
 [submodule "qrcode"]
 	path = feedstocks/qrcode
 	url = https://github.com/conda-forge/qrcode-feedstock.git
+	branch = refs/heads/master
 [submodule "spyre"]
 	path = feedstocks/spyre
 	url = https://github.com/conda-forge/spyre-feedstock.git
+	branch = refs/heads/master
 [submodule "uncertainties"]
 	path = feedstocks/uncertainties
 	url = https://github.com/conda-forge/uncertainties-feedstock.git
+	branch = refs/heads/master
 [submodule "utide"]
 	path = feedstocks/utide
 	url = https://github.com/conda-forge/utide-feedstock.git
+	branch = refs/heads/master
 [submodule "libtiff"]
 	path = feedstocks/libtiff
 	url = https://github.com/conda-forge/libtiff-feedstock.git
+	branch = refs/heads/master
 [submodule "python-ecmwf_grib"]
 	path = feedstocks/python-ecmwf_grib
 	url = https://github.com/conda-forge/python-ecmwf_grib-feedstock.git
+	branch = refs/heads/master
 [submodule "xz"]
 	path = feedstocks/xz
 	url = https://github.com/conda-forge/xz-feedstock.git
+	branch = refs/heads/master
 [submodule "ipyparallel"]
 	path = feedstocks/ipyparallel
 	url = https://github.com/conda-forge/ipyparallel-feedstock.git
+	branch = refs/heads/master
 [submodule "mock"]
 	path = feedstocks/mock
 	url = https://github.com/conda-forge/mock-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.db.base"]
 	path = feedstocks/bob.db.base
 	url = https://github.com/conda-forge/bob.db.base-feedstock.git
+	branch = refs/heads/master
 [submodule "traits"]
 	path = feedstocks/traits
 	url = https://github.com/conda-forge/traits-feedstock.git
+	branch = refs/heads/master
 [submodule "pcre"]
 	path = feedstocks/pcre
 	url = https://github.com/conda-forge/pcre-feedstock.git
+	branch = refs/heads/master
 [submodule "pyface"]
 	path = feedstocks/pyface
 	url = https://github.com/conda-forge/pyface-feedstock.git
+	branch = refs/heads/master
 [submodule "traitsui"]
 	path = feedstocks/traitsui
 	url = https://github.com/conda-forge/traitsui-feedstock.git
+	branch = refs/heads/master
 [submodule "libsigcpp"]
 	path = feedstocks/libsigcpp
 	url = https://github.com/conda-forge/libsigcpp-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.learn.boosting"]
 	path = feedstocks/bob.learn.boosting
 	url = https://github.com/conda-forge/bob.learn.boosting-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.learn.libsvm"]
 	path = feedstocks/bob.learn.libsvm
 	url = https://github.com/conda-forge/bob.learn.libsvm-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.color"]
 	path = feedstocks/bob.ip.color
 	url = https://github.com/conda-forge/bob.ip.color-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.draw"]
 	path = feedstocks/bob.ip.draw
 	url = https://github.com/conda-forge/bob.ip.draw-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.gabor"]
 	path = feedstocks/bob.ip.gabor
 	url = https://github.com/conda-forge/bob.ip.gabor-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.learn.linear"]
 	path = feedstocks/bob.learn.linear
 	url = https://github.com/conda-forge/bob.learn.linear-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.learn.mlp"]
 	path = feedstocks/bob.learn.mlp
 	url = https://github.com/conda-forge/bob.learn.mlp-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.db.mnist"]
 	path = feedstocks/bob.db.mnist
 	url = https://github.com/conda-forge/bob.db.mnist-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.db.wine"]
 	path = feedstocks/bob.db.wine
 	url = https://github.com/conda-forge/bob.db.wine-feedstock.git
+	branch = refs/heads/master
 [submodule "pillow"]
 	path = feedstocks/pillow
 	url = https://github.com/conda-forge/pillow-feedstock.git
+	branch = refs/heads/master
 [submodule "isl"]
 	path = feedstocks/isl
 	url = https://github.com/conda-forge/isl-feedstock.git
+	branch = refs/heads/master
 [submodule "cloog"]
 	path = feedstocks/cloog
 	url = https://github.com/conda-forge/cloog-feedstock.git
+	branch = refs/heads/master
 [submodule "mpl-probscale"]
 	path = feedstocks/mpl-probscale
 	url = https://github.com/conda-forge/mpl-probscale-feedstock.git
+	branch = refs/heads/master
 [submodule "gettext"]
 	path = feedstocks/gettext
 	url = https://github.com/conda-forge/gettext-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.db.atnt"]
 	path = feedstocks/bob.db.atnt
 	url = https://github.com/conda-forge/bob.db.atnt-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.db.iris"]
 	path = feedstocks/bob.db.iris
 	url = https://github.com/conda-forge/bob.db.iris-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.optflow.liu"]
 	path = feedstocks/bob.ip.optflow.liu
 	url = https://github.com/conda-forge/bob.ip.optflow.liu-feedstock.git
+	branch = refs/heads/master
 [submodule "ocgis"]
 	path = feedstocks/ocgis
 	url = https://github.com/conda-forge/ocgis-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.optflow.hornschunck"]
 	path = feedstocks/bob.ip.optflow.hornschunck
 	url = https://github.com/conda-forge/bob.ip.optflow.hornschunck-feedstock.git
+	branch = refs/heads/master
 [submodule "colorama"]
 	path = feedstocks/colorama
 	url = https://github.com/conda-forge/colorama-feedstock.git
+	branch = refs/heads/master
 [submodule "backports.shutil_get_terminal_size"]
 	path = feedstocks/backports.shutil_get_terminal_size
 	url = https://github.com/conda-forge/backports.shutil_get_terminal_size-feedstock.git
+	branch = refs/heads/master
 [submodule "jsonschema"]
 	path = feedstocks/jsonschema
 	url = https://github.com/conda-forge/jsonschema-feedstock.git
+	branch = refs/heads/master
 [submodule "vcversioner"]
 	path = feedstocks/vcversioner
 	url = https://github.com/conda-forge/vcversioner-feedstock.git
+	branch = refs/heads/master
 [submodule "kealib"]
 	path = feedstocks/kealib
 	url = https://github.com/conda-forge/kealib-feedstock.git
+	branch = refs/heads/master
 [submodule "configurable-http-proxy"]
 	path = feedstocks/configurable-http-proxy
 	url = https://github.com/conda-forge/configurable-http-proxy-feedstock.git
+	branch = refs/heads/master
 [submodule "rios"]
 	path = feedstocks/rios
 	url = https://github.com/conda-forge/rios-feedstock.git
+	branch = refs/heads/master
 [submodule "snappy"]
 	path = feedstocks/snappy
 	url = https://github.com/conda-forge/snappy-feedstock.git
+	branch = refs/heads/master
 [submodule "psutil"]
 	path = feedstocks/psutil
 	url = https://github.com/conda-forge/psutil-feedstock.git
+	branch = refs/heads/master
 [submodule "ordered-set"]
 	path = feedstocks/ordered-set
 	url = https://github.com/conda-forge/ordered-set-feedstock.git
+	branch = refs/heads/master
 [submodule "apptools"]
 	path = feedstocks/apptools
 	url = https://github.com/conda-forge/apptools-feedstock.git
+	branch = refs/heads/master
 [submodule "widgetsnbextension"]
 	path = feedstocks/widgetsnbextension
 	url = https://github.com/conda-forge/widgetsnbextension-feedstock.git
+	branch = refs/heads/master
 [submodule "libpng"]
 	path = feedstocks/libpng
 	url = https://github.com/conda-forge/libpng-feedstock.git
+	branch = refs/heads/master
 [submodule "vlfeat"]
 	path = feedstocks/vlfeat
 	url = https://github.com/conda-forge/vlfeat-feedstock.git
+	branch = refs/heads/master
 [submodule "openblas"]
 	path = feedstocks/openblas
 	url = https://github.com/conda-forge/openblas-feedstock.git
+	branch = refs/heads/master
 [submodule "erlang"]
 	path = feedstocks/erlang
 	url = https://github.com/conda-forge/erlang-feedstock.git
+	branch = refs/heads/master
 [submodule "envisage"]
 	path = feedstocks/envisage
 	url = https://github.com/conda-forge/envisage-feedstock.git
+	branch = refs/heads/master
 [submodule "fontconfig"]
 	path = feedstocks/fontconfig
 	url = https://github.com/conda-forge/fontconfig-feedstock.git
+	branch = refs/heads/master
 [submodule "pyomo"]
 	path = feedstocks/pyomo
 	url = https://github.com/conda-forge/pyomo-feedstock.git
+	branch = refs/heads/master
 [submodule "cairo"]
 	path = feedstocks/cairo
 	url = https://github.com/conda-forge/cairo-feedstock.git
+	branch = refs/heads/master
 [submodule "eccodes"]
 	path = feedstocks/eccodes
 	url = https://github.com/conda-forge/eccodes-feedstock.git
+	branch = refs/heads/master
 [submodule "invoke"]
 	path = feedstocks/invoke
 	url = https://github.com/conda-forge/invoke-feedstock.git
+	branch = refs/heads/master
 [submodule "phreeqpy"]
 	path = feedstocks/phreeqpy
 	url = https://github.com/conda-forge/phreeqpy-feedstock.git
+	branch = refs/heads/master
 [submodule "iris"]
 	path = feedstocks/iris
 	url = https://github.com/conda-forge/iris-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.base"]
 	path = feedstocks/bob.ip.base
 	url = https://github.com/conda-forge/bob.ip.base-feedstock.git
+	branch = refs/heads/master
 [submodule "tabulate"]
 	path = feedstocks/tabulate
 	url = https://github.com/conda-forge/tabulate-feedstock.git
+	branch = refs/heads/master
 [submodule "termcolor"]
 	path = feedstocks/termcolor
 	url = https://github.com/conda-forge/termcolor-feedstock.git
+	branch = refs/heads/master
 [submodule "cloud_sptheme"]
 	path = feedstocks/cloud_sptheme
 	url = https://github.com/conda-forge/cloud_sptheme-feedstock.git
+	branch = refs/heads/master
 [submodule "nose-timer"]
 	path = feedstocks/nose-timer
 	url = https://github.com/conda-forge/nose-timer-feedstock.git
+	branch = refs/heads/master
 [submodule "python-coveralls"]
 	path = feedstocks/python-coveralls
 	url = https://github.com/conda-forge/python-coveralls-feedstock.git
+	branch = refs/heads/master
 [submodule "docstring-coverage"]
 	path = feedstocks/docstring-coverage
 	url = https://github.com/conda-forge/docstring-coverage-feedstock.git
+	branch = refs/heads/master
 [submodule "helper"]
 	path = feedstocks/helper
 	url = https://github.com/conda-forge/helper-feedstock.git
+	branch = refs/heads/master
 [submodule "pika"]
 	path = feedstocks/pika
 	url = https://github.com/conda-forge/pika-feedstock.git
+	branch = refs/heads/master
 [submodule "miktex"]
 	path = feedstocks/miktex
 	url = https://github.com/conda-forge/miktex-feedstock.git
+	branch = refs/heads/master
 [submodule "rejected"]
 	path = feedstocks/rejected
 	url = https://github.com/conda-forge/rejected-feedstock.git
+	branch = refs/heads/master
 [submodule "jinja2"]
 	path = feedstocks/jinja2
 	url = https://github.com/conda-forge/jinja2-feedstock.git
+	branch = refs/heads/master
 [submodule "serpent"]
 	path = feedstocks/serpent
 	url = https://github.com/conda-forge/serpent-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.facedetect"]
 	path = feedstocks/bob.ip.facedetect
 	url = https://github.com/conda-forge/bob.ip.facedetect-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.learn.em"]
 	path = feedstocks/bob.learn.em
 	url = https://github.com/conda-forge/bob.learn.em-feedstock.git
+	branch = refs/heads/master
 [submodule "nose"]
 	path = feedstocks/nose
 	url = https://github.com/conda-forge/nose-feedstock.git
+	branch = refs/heads/master
 [submodule "spyder"]
 	path = feedstocks/spyder
 	url = https://github.com/conda-forge/spyder-feedstock.git
+	branch = refs/heads/master
 [submodule "cython"]
 	path = feedstocks/cython
 	url = https://github.com/conda-forge/cython-feedstock.git
+	branch = refs/heads/master
 [submodule "bob"]
 	path = feedstocks/bob
 	url = https://github.com/conda-forge/bob-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas"]
 	path = feedstocks/pandas
 	url = https://github.com/conda-forge/pandas-feedstock.git
+	branch = refs/heads/master
 [submodule "feather-format"]
 	path = feedstocks/feather-format
 	url = https://github.com/conda-forge/feather-format-feedstock.git
+	branch = refs/heads/master
 [submodule "mpmath"]
 	path = feedstocks/mpmath
 	url = https://github.com/conda-forge/mpmath-feedstock.git
+	branch = refs/heads/master
 [submodule "sympy"]
 	path = feedstocks/sympy
 	url = https://github.com/conda-forge/sympy-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyterhub"]
 	path = feedstocks/jupyterhub
 	url = https://github.com/conda-forge/jupyterhub-feedstock.git
+	branch = refs/heads/master
 [submodule "pamela"]
 	path = feedstocks/pamela
 	url = https://github.com/conda-forge/pamela-feedstock.git
+	branch = refs/heads/master
 [submodule "tempita"]
 	path = feedstocks/tempita
 	url = https://github.com/conda-forge/tempita-feedstock.git
+	branch = refs/heads/master
 [submodule "bqplot"]
 	path = feedstocks/bqplot
 	url = https://github.com/conda-forge/bqplot-feedstock.git
+	branch = refs/heads/master
 [submodule "pythreejs"]
 	path = feedstocks/pythreejs
 	url = https://github.com/conda-forge/pythreejs-feedstock.git
+	branch = refs/heads/master
 [submodule "ipyleaflet"]
 	path = feedstocks/ipyleaflet
 	url = https://github.com/conda-forge/ipyleaflet-feedstock.git
+	branch = refs/heads/master
 [submodule "cis"]
 	path = feedstocks/cis
 	url = https://github.com/conda-forge/cis-feedstock.git
+	branch = refs/heads/master
 [submodule "pyhamcrest"]
 	path = feedstocks/pyhamcrest
 	url = https://github.com/conda-forge/pyhamcrest-feedstock.git
+	branch = refs/heads/master
 [submodule "ca-certificates"]
 	path = feedstocks/ca-certificates
 	url = https://github.com/conda-forge/ca-certificates-feedstock.git
+	branch = refs/heads/master
 [submodule "gnureadline"]
 	path = feedstocks/gnureadline
 	url = https://github.com/conda-forge/gnureadline-feedstock.git
+	branch = refs/heads/master
 [submodule "tuiview"]
 	path = feedstocks/tuiview
 	url = https://github.com/conda-forge/tuiview-feedstock.git
+	branch = refs/heads/master
 [submodule "vc"]
 	path = feedstocks/vc
 	url = https://github.com/conda-forge/vc-feedstock.git
+	branch = refs/heads/master
 [submodule "pypandoc"]
 	path = feedstocks/pypandoc
 	url = https://github.com/conda-forge/pypandoc-feedstock.git
+	branch = refs/heads/master
 [submodule "bottleneck"]
 	path = feedstocks/bottleneck
 	url = https://github.com/conda-forge/bottleneck-feedstock.git
+	branch = refs/heads/master
 [submodule "nose_parameterized"]
 	path = feedstocks/nose_parameterized
 	url = https://github.com/conda-forge/nose_parameterized-feedstock.git
+	branch = refs/heads/master
 [submodule "glib"]
 	path = feedstocks/glib
 	url = https://github.com/conda-forge/glib-feedstock.git
+	branch = refs/heads/master
 [submodule "nibabel"]
 	path = feedstocks/nibabel
 	url = https://github.com/conda-forge/nibabel-feedstock.git
+	branch = refs/heads/master
 [submodule "six"]
 	path = feedstocks/six
 	url = https://github.com/conda-forge/six-feedstock.git
+	branch = refs/heads/master
 [submodule "cdat-lite"]
 	path = feedstocks/cdat-lite
 	url = https://github.com/conda-forge/cdat-lite-feedstock.git
+	branch = refs/heads/master
 [submodule "cfchecker"]
 	path = feedstocks/cfchecker
 	url = https://github.com/conda-forge/cfchecker-feedstock.git
+	branch = refs/heads/master
 [submodule "openssl"]
 	path = feedstocks/openssl
 	url = https://github.com/conda-forge/openssl-feedstock.git
+	branch = refs/heads/master
 [submodule "pytz"]
 	path = feedstocks/pytz
 	url = https://github.com/conda-forge/pytz-feedstock.git
+	branch = refs/heads/master
 [submodule "pybind11"]
 	path = feedstocks/pybind11
 	url = https://github.com/conda-forge/pybind11-feedstock.git
+	branch = refs/heads/master
 [submodule "freetype"]
 	path = feedstocks/freetype
 	url = https://github.com/conda-forge/freetype-feedstock.git
+	branch = refs/heads/master
 [submodule "flatbuffers"]
 	path = feedstocks/flatbuffers
 	url = https://github.com/conda-forge/flatbuffers-feedstock.git
+	branch = refs/heads/master
 [submodule "capnproto"]
 	path = feedstocks/capnproto
 	url = https://github.com/conda-forge/capnproto-feedstock.git
+	branch = refs/heads/master
 [submodule "sqlite"]
 	path = feedstocks/sqlite
 	url = https://github.com/conda-forge/sqlite-feedstock.git
+	branch = refs/heads/master
 [submodule "cunit"]
 	path = feedstocks/cunit
 	url = https://github.com/conda-forge/cunit-feedstock.git
+	branch = refs/heads/master
 [submodule "nfft"]
 	path = feedstocks/nfft
 	url = https://github.com/conda-forge/nfft-feedstock.git
+	branch = refs/heads/master
 [submodule "pynfft"]
 	path = feedstocks/pynfft
 	url = https://github.com/conda-forge/pynfft-feedstock.git
+	branch = refs/heads/master
 [submodule "glibmm"]
 	path = feedstocks/glibmm
 	url = https://github.com/conda-forge/glibmm-feedstock.git
+	branch = refs/heads/master
 [submodule "thrift-cpp"]
 	path = feedstocks/thrift-cpp
 	url = https://github.com/conda-forge/thrift-cpp-feedstock.git
+	branch = refs/heads/master
 [submodule "libxmlpp"]
 	path = feedstocks/libxmlpp
 	url = https://github.com/conda-forge/libxmlpp-feedstock.git
+	branch = refs/heads/master
 [submodule "glueviz"]
 	path = feedstocks/glueviz
 	url = https://github.com/conda-forge/glueviz-feedstock.git
+	branch = refs/heads/master
 [submodule "nilearn"]
 	path = feedstocks/nilearn
 	url = https://github.com/conda-forge/nilearn-feedstock.git
+	branch = refs/heads/master
 [submodule "python-dateutil"]
 	path = feedstocks/python-dateutil
 	url = https://github.com/conda-forge/python-dateutil-feedstock.git
+	branch = refs/heads/master
 [submodule "supervisor"]
 	path = feedstocks/supervisor
 	url = https://github.com/conda-forge/supervisor-feedstock.git
+	branch = refs/heads/master
 [submodule "glue-vispy-viewers"]
 	path = feedstocks/glue-vispy-viewers
 	url = https://github.com/conda-forge/glue-vispy-viewers-feedstock.git
+	branch = refs/heads/master
 [submodule "lua"]
 	path = feedstocks/lua
 	url = https://github.com/conda-forge/lua-feedstock.git
+	branch = refs/heads/master
 [submodule "pycapnp"]
 	path = feedstocks/pycapnp
 	url = https://github.com/conda-forge/pycapnp-feedstock.git
+	branch = refs/heads/master
 [submodule "qtconsole"]
 	path = feedstocks/qtconsole
 	url = https://github.com/conda-forge/qtconsole-feedstock.git
+	branch = refs/heads/master
 [submodule "coincbc"]
 	path = feedstocks/coincbc
 	url = https://github.com/conda-forge/coincbc-feedstock.git
+	branch = refs/heads/master
 [submodule "doct"]
 	path = feedstocks/doct
 	url = https://github.com/conda-forge/doct-feedstock.git
+	branch = refs/heads/master
 [submodule "readline"]
 	path = feedstocks/readline
 	url = https://github.com/conda-forge/readline-feedstock.git
+	branch = refs/heads/master
 [submodule "distributed"]
 	path = feedstocks/distributed
 	url = https://github.com/conda-forge/distributed-feedstock.git
+	branch = refs/heads/master
 [submodule "dask"]
 	path = feedstocks/dask
 	url = https://github.com/conda-forge/dask-feedstock.git
+	branch = refs/heads/master
 [submodule "glymur"]
 	path = feedstocks/glymur
 	url = https://github.com/conda-forge/glymur-feedstock.git
+	branch = refs/heads/master
 [submodule "sunpy"]
 	path = feedstocks/sunpy
 	url = https://github.com/conda-forge/sunpy-feedstock.git
+	branch = refs/heads/master
 [submodule "wcsaxes"]
 	path = feedstocks/wcsaxes
 	url = https://github.com/conda-forge/wcsaxes-feedstock.git
+	branch = refs/heads/master
 [submodule "s3fs"]
 	path = feedstocks/s3fs
 	url = https://github.com/conda-forge/s3fs-feedstock.git
+	branch = refs/heads/master
 [submodule "tbb"]
 	path = feedstocks/tbb
 	url = https://github.com/conda-forge/tbb-feedstock.git
+	branch = refs/heads/master
 [submodule "fasteners"]
 	path = feedstocks/fasteners
 	url = https://github.com/conda-forge/fasteners-feedstock.git
+	branch = refs/heads/master
 [submodule "monotonic"]
 	path = feedstocks/monotonic
 	url = https://github.com/conda-forge/monotonic-feedstock.git
+	branch = refs/heads/master
 [submodule "zarr"]
 	path = feedstocks/zarr
 	url = https://github.com/conda-forge/zarr-feedstock.git
+	branch = refs/heads/master
 [submodule "toolchain"]
 	path = feedstocks/toolchain
 	url = https://github.com/conda-forge/toolchain-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-forge-build-setup"]
 	path = feedstocks/conda-forge-build-setup
 	url = https://github.com/conda-forge/conda-forge-build-setup-feedstock.git
+	branch = refs/heads/master
 [submodule "tk"]
 	path = feedstocks/tk
 	url = https://github.com/conda-forge/tk-feedstock.git
+	branch = refs/heads/master
 [submodule "arrow"]
 	path = feedstocks/arrow
 	url = https://github.com/conda-forge/arrow-feedstock.git
+	branch = refs/heads/master
 [submodule "binaryornot"]
 	path = feedstocks/binaryornot
 	url = https://github.com/conda-forge/binaryornot-feedstock.git
+	branch = refs/heads/master
 [submodule "cookiecutter"]
 	path = feedstocks/cookiecutter
 	url = https://github.com/conda-forge/cookiecutter-feedstock.git
+	branch = refs/heads/master
 [submodule "jinja2-time"]
 	path = feedstocks/jinja2-time
 	url = https://github.com/conda-forge/jinja2-time-feedstock.git
+	branch = refs/heads/master
 [submodule "lapack"]
 	path = feedstocks/lapack
 	url = https://github.com/conda-forge/lapack-feedstock.git
+	branch = refs/heads/master
 [submodule "poyo"]
 	path = feedstocks/poyo
 	url = https://github.com/conda-forge/poyo-feedstock.git
+	branch = refs/heads/master
 [submodule "whichcraft"]
 	path = feedstocks/whichcraft
 	url = https://github.com/conda-forge/whichcraft-feedstock.git
+	branch = refs/heads/master
 [submodule "dipy"]
 	path = feedstocks/dipy
 	url = https://github.com/conda-forge/dipy-feedstock.git
+	branch = refs/heads/master
 [submodule "muparser"]
 	path = feedstocks/muparser
 	url = https://github.com/conda-forge/muparser-feedstock.git
+	branch = refs/heads/master
 [submodule "libradolan"]
 	path = feedstocks/libradolan
 	url = https://github.com/conda-forge/libradolan-feedstock.git
+	branch = refs/heads/master
 [submodule "nlopt"]
 	path = feedstocks/nlopt
 	url = https://github.com/conda-forge/nlopt-feedstock.git
+	branch = refs/heads/master
 [submodule "blas"]
 	path = feedstocks/blas
 	url = https://github.com/conda-forge/blas-feedstock.git
+	branch = refs/heads/master
 [submodule "curl"]
 	path = feedstocks/curl
 	url = https://github.com/conda-forge/curl-feedstock.git
+	branch = refs/heads/master
 [submodule "libgsasl"]
 	path = feedstocks/libgsasl
 	url = https://github.com/conda-forge/libgsasl-feedstock.git
+	branch = refs/heads/master
 [submodule "libntlm"]
 	path = feedstocks/libntlm
 	url = https://github.com/conda-forge/libntlm-feedstock.git
+	branch = refs/heads/master
 [submodule "pvlib-python"]
 	path = feedstocks/pvlib-python
 	url = https://github.com/conda-forge/pvlib-python-feedstock.git
+	branch = refs/heads/master
 [submodule "python"]
 	path = feedstocks/python
 	url = https://github.com/conda-forge/python-feedstock.git
+	branch = refs/heads/master
 [submodule "numpy"]
 	path = feedstocks/numpy
 	url = https://github.com/conda-forge/numpy-feedstock.git
+	branch = refs/heads/master
 [submodule "uwsgi"]
 	path = feedstocks/uwsgi
 	url = https://github.com/conda-forge/uwsgi-feedstock.git
+	branch = refs/heads/master
 [submodule "scipy"]
 	path = feedstocks/scipy
 	url = https://github.com/conda-forge/scipy-feedstock.git
+	branch = refs/heads/master
 [submodule "libhdfs3"]
 	path = feedstocks/libhdfs3
 	url = https://github.com/conda-forge/libhdfs3-feedstock.git
+	branch = refs/heads/master
 [submodule "dec2"]
 	path = feedstocks/dec2
 	url = https://github.com/conda-forge/dec2-feedstock.git
+	branch = refs/heads/master
 [submodule "emcee"]
 	path = feedstocks/emcee
 	url = https://github.com/conda-forge/emcee-feedstock.git
+	branch = refs/heads/master
 [submodule "lmfit"]
 	path = feedstocks/lmfit
 	url = https://github.com/conda-forge/lmfit-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-image"]
 	path = feedstocks/scikit-image
 	url = https://github.com/conda-forge/scikit-image-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-learn"]
 	path = feedstocks/scikit-learn
 	url = https://github.com/conda-forge/scikit-learn-feedstock.git
+	branch = refs/heads/master
 [submodule "python-spams"]
 	path = feedstocks/python-spams
 	url = https://github.com/conda-forge/python-spams-feedstock.git
+	branch = refs/heads/master
 [submodule "holoviews"]
 	path = feedstocks/holoviews
 	url = https://github.com/conda-forge/holoviews-feedstock.git
+	branch = refs/heads/master
 [submodule "cvxopt"]
 	path = feedstocks/cvxopt
 	url = https://github.com/conda-forge/cvxopt-feedstock.git
+	branch = refs/heads/master
 [submodule "libnetcdf"]
 	path = feedstocks/libnetcdf
 	url = https://github.com/conda-forge/libnetcdf-feedstock.git
+	branch = refs/heads/master
 [submodule "hmat-oss"]
 	path = feedstocks/hmat-oss
 	url = https://github.com/conda-forge/hmat-oss-feedstock.git
+	branch = refs/heads/master
 [submodule "freeglut"]
 	path = feedstocks/freeglut
 	url = https://github.com/conda-forge/freeglut-feedstock.git
+	branch = refs/heads/master
 [submodule "pyro4"]
 	path = feedstocks/pyro4
 	url = https://github.com/conda-forge/pyro4-feedstock.git
+	branch = refs/heads/master
 [submodule "libgd"]
 	path = feedstocks/libgd
 	url = https://github.com/conda-forge/libgd-feedstock.git
+	branch = refs/heads/master
 [submodule "event-model"]
 	path = feedstocks/event-model
 	url = https://github.com/conda-forge/event-model-feedstock.git
+	branch = refs/heads/master
 [submodule "args"]
 	path = feedstocks/args
 	url = https://github.com/conda-forge/args-feedstock.git
+	branch = refs/heads/master
 [submodule "clint"]
 	path = feedstocks/clint
 	url = https://github.com/conda-forge/clint-feedstock.git
+	branch = refs/heads/master
 [submodule "pkginfo"]
 	path = feedstocks/pkginfo
 	url = https://github.com/conda-forge/pkginfo-feedstock.git
+	branch = refs/heads/master
 [submodule "pytools"]
 	path = feedstocks/pytools
 	url = https://github.com/conda-forge/pytools-feedstock.git
+	branch = refs/heads/master
 [submodule "boltons"]
 	path = feedstocks/boltons
 	url = https://github.com/conda-forge/boltons-feedstock.git
+	branch = refs/heads/master
 [submodule "keyring"]
 	path = feedstocks/keyring
 	url = https://github.com/conda-forge/keyring-feedstock.git
+	branch = refs/heads/master
 [submodule "line_profiler"]
 	path = feedstocks/line_profiler
 	url = https://github.com/conda-forge/line_profiler-feedstock.git
+	branch = refs/heads/master
 [submodule "memory_profiler"]
 	path = feedstocks/memory_profiler
 	url = https://github.com/conda-forge/memory_profiler-feedstock.git
+	branch = refs/heads/master
 [submodule "openturns"]
 	path = feedstocks/openturns
 	url = https://github.com/conda-forge/openturns-feedstock.git
+	branch = refs/heads/master
 [submodule "ipycache"]
 	path = feedstocks/ipycache
 	url = https://github.com/conda-forge/ipycache-feedstock.git
+	branch = refs/heads/master
 [submodule "effect"]
 	path = feedstocks/effect
 	url = https://github.com/conda-forge/effect-feedstock.git
+	branch = refs/heads/master
 [submodule "historydict"]
 	path = feedstocks/historydict
 	url = https://github.com/conda-forge/historydict-feedstock.git
+	branch = refs/heads/master
 [submodule "slicerator"]
 	path = feedstocks/slicerator
 	url = https://github.com/conda-forge/slicerator-feedstock.git
+	branch = refs/heads/master
 [submodule "xraylib"]
 	path = feedstocks/xraylib
 	url = https://github.com/conda-forge/xraylib-feedstock.git
+	branch = refs/heads/master
 [submodule "pyomo.extras"]
 	path = feedstocks/pyomo.extras
 	url = https://github.com/conda-forge/pyomo.extras-feedstock.git
+	branch = refs/heads/master
 [submodule "m2crypto"]
 	path = feedstocks/m2crypto
 	url = https://github.com/conda-forge/m2crypto-feedstock.git
+	branch = refs/heads/master
 [submodule "suitesparse"]
 	path = feedstocks/suitesparse
 	url = https://github.com/conda-forge/suitesparse-feedstock.git
+	branch = refs/heads/master
 [submodule "pycosat"]
 	path = feedstocks/pycosat
 	url = https://github.com/conda-forge/pycosat-feedstock.git
+	branch = refs/heads/master
 [submodule "requests"]
 	path = feedstocks/requests
 	url = https://github.com/conda-forge/requests-feedstock.git
+	branch = refs/heads/master
 [submodule "yaml"]
 	path = feedstocks/yaml
 	url = https://github.com/conda-forge/yaml-feedstock.git
+	branch = refs/heads/master
 [submodule "pyyaml"]
 	path = feedstocks/pyyaml
 	url = https://github.com/conda-forge/pyyaml-feedstock.git
+	branch = refs/heads/master
 [submodule "nbpresent"]
 	path = feedstocks/nbpresent
 	url = https://github.com/conda-forge/nbpresent-feedstock.git
+	branch = refs/heads/master
 [submodule "healpy"]
 	path = feedstocks/healpy
 	url = https://github.com/conda-forge/healpy-feedstock.git
+	branch = refs/heads/master
 [submodule "cytoolz"]
 	path = feedstocks/cytoolz
 	url = https://github.com/conda-forge/cytoolz-feedstock.git
+	branch = refs/heads/master
 [submodule "toolz"]
 	path = feedstocks/toolz
 	url = https://github.com/conda-forge/toolz-feedstock.git
+	branch = refs/heads/master
 [submodule "vega"]
 	path = feedstocks/vega
 	url = https://github.com/conda-forge/vega-feedstock.git
+	branch = refs/heads/master
 [submodule "python-neo"]
 	path = feedstocks/python-neo
 	url = https://github.com/conda-forge/python-neo-feedstock.git
+	branch = refs/heads/master
 [submodule "tqdm"]
 	path = feedstocks/tqdm
 	url = https://github.com/conda-forge/tqdm-feedstock.git
+	branch = refs/heads/master
 [submodule "sip"]
 	path = feedstocks/sip
 	url = https://github.com/conda-forge/sip-feedstock.git
+	branch = refs/heads/master
 [submodule "thinkx"]
 	path = feedstocks/thinkx
 	url = https://github.com/conda-forge/thinkx-feedstock.git
+	branch = refs/heads/master
 [submodule "pytmatrix"]
 	path = feedstocks/pytmatrix
 	url = https://github.com/conda-forge/pytmatrix-feedstock.git
+	branch = refs/heads/master
 [submodule "nb_anacondacloud"]
 	path = feedstocks/nb_anacondacloud
 	url = https://github.com/conda-forge/nb_anacondacloud-feedstock.git
+	branch = refs/heads/master
 [submodule "assetid"]
 	path = feedstocks/assetid
 	url = https://github.com/conda-forge/assetid-feedstock.git
+	branch = refs/heads/master
 [submodule "tika"]
 	path = feedstocks/tika
 	url = https://github.com/conda-forge/tika-feedstock.git
+	branch = refs/heads/master
 [submodule "apache-libcloud"]
 	path = feedstocks/apache-libcloud
 	url = https://github.com/conda-forge/apache-libcloud-feedstock.git
+	branch = refs/heads/master
 [submodule "salt"]
 	path = feedstocks/salt
 	url = https://github.com/conda-forge/salt-feedstock.git
+	branch = refs/heads/master
 [submodule "dill"]
 	path = feedstocks/dill
 	url = https://github.com/conda-forge/dill-feedstock.git
+	branch = refs/heads/master
 [submodule "namedlist"]
 	path = feedstocks/namedlist
 	url = https://github.com/conda-forge/namedlist-feedstock.git
+	branch = refs/heads/master
 [submodule "y_serial"]
 	path = feedstocks/y_serial
 	url = https://github.com/conda-forge/y_serial-feedstock.git
+	branch = refs/heads/master
 [submodule "cmocean"]
 	path = feedstocks/cmocean
 	url = https://github.com/conda-forge/cmocean-feedstock.git
+	branch = refs/heads/master
 [submodule "locket"]
 	path = feedstocks/locket
 	url = https://github.com/conda-forge/locket-feedstock.git
+	branch = refs/heads/master
 [submodule "partd"]
 	path = feedstocks/partd
 	url = https://github.com/conda-forge/partd-feedstock.git
+	branch = refs/heads/master
 [submodule "pykalman"]
 	path = feedstocks/pykalman
 	url = https://github.com/conda-forge/pykalman-feedstock.git
+	branch = refs/heads/master
 [submodule "statsd"]
 	path = feedstocks/statsd
 	url = https://github.com/conda-forge/statsd-feedstock.git
+	branch = refs/heads/master
 [submodule "pyparsing"]
 	path = feedstocks/pyparsing
 	url = https://github.com/conda-forge/pyparsing-feedstock.git
+	branch = refs/heads/master
 [submodule "autopep8"]
 	path = feedstocks/autopep8
 	url = https://github.com/conda-forge/autopep8-feedstock.git
+	branch = refs/heads/master
 [submodule "dcmstack"]
 	path = feedstocks/dcmstack
 	url = https://github.com/conda-forge/dcmstack-feedstock.git
+	branch = refs/heads/master
 [submodule "deap"]
 	path = feedstocks/deap
 	url = https://github.com/conda-forge/deap-feedstock.git
+	branch = refs/heads/master
 [submodule "graphviz"]
 	path = feedstocks/graphviz
 	url = https://github.com/conda-forge/graphviz-feedstock.git
+	branch = refs/heads/master
 [submodule "hdfs3"]
 	path = feedstocks/hdfs3
 	url = https://github.com/conda-forge/hdfs3-feedstock.git
+	branch = refs/heads/master
 [submodule "krb5"]
 	path = feedstocks/krb5
 	url = https://github.com/conda-forge/krb5-feedstock.git
+	branch = refs/heads/master
 [submodule "matplotlib-venn"]
 	path = feedstocks/matplotlib-venn
 	url = https://github.com/conda-forge/matplotlib-venn-feedstock.git
+	branch = refs/heads/master
 [submodule "nb_conda_kernels"]
 	path = feedstocks/nb_conda_kernels
 	url = https://github.com/conda-forge/nb_conda_kernels-feedstock.git
+	branch = refs/heads/master
 [submodule "pep8"]
 	path = feedstocks/pep8
 	url = https://github.com/conda-forge/pep8-feedstock.git
+	branch = refs/heads/master
 [submodule "pycodestyle"]
 	path = feedstocks/pycodestyle
 	url = https://github.com/conda-forge/pycodestyle-feedstock.git
+	branch = refs/heads/master
 [submodule "python-eccodes"]
 	path = feedstocks/python-eccodes
 	url = https://github.com/conda-forge/python-eccodes-feedstock.git
+	branch = refs/heads/master
 [submodule "yapf"]
 	path = feedstocks/yapf
 	url = https://github.com/conda-forge/yapf-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-common"]
 	path = feedstocks/azure-common
 	url = https://github.com/conda-forge/azure-common-feedstock.git
+	branch = refs/heads/master
 [submodule "azure"]
 	path = feedstocks/azure
 	url = https://github.com/conda-forge/azure-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-mgmt-common"]
 	path = feedstocks/azure-mgmt-common
 	url = https://github.com/conda-forge/azure-mgmt-common-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-mgmt-compute"]
 	path = feedstocks/azure-mgmt-compute
 	url = https://github.com/conda-forge/azure-mgmt-compute-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-mgmt"]
 	path = feedstocks/azure-mgmt
 	url = https://github.com/conda-forge/azure-mgmt-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-mgmt-network"]
 	path = feedstocks/azure-mgmt-network
 	url = https://github.com/conda-forge/azure-mgmt-network-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-mgmt-nspkg"]
 	path = feedstocks/azure-mgmt-nspkg
 	url = https://github.com/conda-forge/azure-mgmt-nspkg-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-mgmt-resource"]
 	path = feedstocks/azure-mgmt-resource
 	url = https://github.com/conda-forge/azure-mgmt-resource-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-mgmt-storage"]
 	path = feedstocks/azure-mgmt-storage
 	url = https://github.com/conda-forge/azure-mgmt-storage-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-nspkg"]
 	path = feedstocks/azure-nspkg
 	url = https://github.com/conda-forge/azure-nspkg-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-servicebus"]
 	path = feedstocks/azure-servicebus
 	url = https://github.com/conda-forge/azure-servicebus-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-servicemanagement-legacy"]
 	path = feedstocks/azure-servicemanagement-legacy
 	url = https://github.com/conda-forge/azure-servicemanagement-legacy-feedstock.git
+	branch = refs/heads/master
 [submodule "azure-storage"]
 	path = feedstocks/azure-storage
 	url = https://github.com/conda-forge/azure-storage-feedstock.git
+	branch = refs/heads/master
 [submodule "cc-plugin-ncei"]
 	path = feedstocks/cc-plugin-ncei
 	url = https://github.com/conda-forge/cc-plugin-ncei-feedstock.git
+	branch = refs/heads/master
 [submodule "cherrypy"]
 	path = feedstocks/cherrypy
 	url = https://github.com/conda-forge/cherrypy-feedstock.git
+	branch = refs/heads/master
 [submodule "texlive-core"]
 	path = feedstocks/texlive-core
 	url = https://github.com/conda-forge/texlive-core-feedstock.git
+	branch = refs/heads/master
 [submodule "brewer2mpl"]
 	path = feedstocks/brewer2mpl
 	url = https://github.com/conda-forge/brewer2mpl-feedstock.git
+	branch = refs/heads/master
 [submodule "ggplot"]
 	path = feedstocks/ggplot
 	url = https://github.com/conda-forge/ggplot-feedstock.git
+	branch = refs/heads/master
 [submodule "pycrypto"]
 	path = feedstocks/pycrypto
 	url = https://github.com/conda-forge/pycrypto-feedstock.git
+	branch = refs/heads/master
 [submodule "python-symengine"]
 	path = feedstocks/python-symengine
 	url = https://github.com/conda-forge/python-symengine-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-sparse"]
 	path = feedstocks/scikit-sparse
 	url = https://github.com/conda-forge/scikit-sparse-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-umfpack"]
 	path = feedstocks/scikit-umfpack
 	url = https://github.com/conda-forge/scikit-umfpack-feedstock.git
+	branch = refs/heads/master
 [submodule "symengine"]
 	path = feedstocks/symengine
 	url = https://github.com/conda-forge/symengine-feedstock.git
+	branch = refs/heads/master
 [submodule "geoalchemy2"]
 	path = feedstocks/geoalchemy2
 	url = https://github.com/conda-forge/geoalchemy2-feedstock.git
+	branch = refs/heads/master
 [submodule "numpy-indexed"]
 	path = feedstocks/numpy-indexed
 	url = https://github.com/conda-forge/numpy-indexed-feedstock.git
+	branch = refs/heads/master
 [submodule "phonenumbers"]
 	path = feedstocks/phonenumbers
 	url = https://github.com/conda-forge/phonenumbers-feedstock.git
+	branch = refs/heads/master
 [submodule "django-rest-hooks"]
 	path = feedstocks/django-rest-hooks
 	url = https://github.com/conda-forge/django-rest-hooks-feedstock.git
+	branch = refs/heads/master
 [submodule "findspark"]
 	path = feedstocks/findspark
 	url = https://github.com/conda-forge/findspark-feedstock.git
+	branch = refs/heads/master
 [submodule "libarchive"]
 	path = feedstocks/libarchive
 	url = https://github.com/conda-forge/libarchive-feedstock.git
+	branch = refs/heads/master
 [submodule "mutagen"]
 	path = feedstocks/mutagen
 	url = https://github.com/conda-forge/mutagen-feedstock.git
+	branch = refs/heads/master
 [submodule "packaging"]
 	path = feedstocks/packaging
 	url = https://github.com/conda-forge/packaging-feedstock.git
+	branch = refs/heads/master
 [submodule "vs2015_runtime"]
 	path = feedstocks/vs2015_runtime
 	url = https://github.com/conda-forge/vs2015_runtime-feedstock.git
+	branch = refs/heads/master
 [submodule "jsoncpp"]
 	path = feedstocks/jsoncpp
 	url = https://github.com/conda-forge/jsoncpp-feedstock.git
+	branch = refs/heads/master
 [submodule "libmemcached"]
 	path = feedstocks/libmemcached
 	url = https://github.com/conda-forge/libmemcached-feedstock.git
+	branch = refs/heads/master
 [submodule "mongoquery"]
 	path = feedstocks/mongoquery
 	url = https://github.com/conda-forge/mongoquery-feedstock.git
+	branch = refs/heads/master
 [submodule "pyopcode"]
 	path = feedstocks/pyopcode
 	url = https://github.com/conda-forge/pyopcode-feedstock.git
+	branch = refs/heads/master
 [submodule "scp"]
 	path = feedstocks/scp
 	url = https://github.com/conda-forge/scp-feedstock.git
+	branch = refs/heads/master
 [submodule "slacker"]
 	path = feedstocks/slacker
 	url = https://github.com/conda-forge/slacker-feedstock.git
+	branch = refs/heads/master
 [submodule "tinydb"]
 	path = feedstocks/tinydb
 	url = https://github.com/conda-forge/tinydb-feedstock.git
+	branch = refs/heads/master
 [submodule "ecmwf-api-client"]
 	path = feedstocks/ecmwf-api-client
 	url = https://github.com/conda-forge/ecmwf-api-client-feedstock.git
+	branch = refs/heads/master
 [submodule "ffx"]
 	path = feedstocks/ffx
 	url = https://github.com/conda-forge/ffx-feedstock.git
+	branch = refs/heads/master
 [submodule "clusterpy"]
 	path = feedstocks/clusterpy
 	url = https://github.com/conda-forge/clusterpy-feedstock.git
+	branch = refs/heads/master
 [submodule "dxchange"]
 	path = feedstocks/dxchange
 	url = https://github.com/conda-forge/dxchange-feedstock.git
+	branch = refs/heads/master
 [submodule "dxfile"]
 	path = feedstocks/dxfile
 	url = https://github.com/conda-forge/dxfile-feedstock.git
+	branch = refs/heads/master
 [submodule "edffile"]
 	path = feedstocks/edffile
 	url = https://github.com/conda-forge/edffile-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-sqlalchemy"]
 	path = feedstocks/flask-sqlalchemy
 	url = https://github.com/conda-forge/flask-sqlalchemy-feedstock.git
+	branch = refs/heads/master
 [submodule "happybase"]
 	path = feedstocks/happybase
 	url = https://github.com/conda-forge/happybase-feedstock.git
+	branch = refs/heads/master
 [submodule "lifelines"]
 	path = feedstocks/lifelines
 	url = https://github.com/conda-forge/lifelines-feedstock.git
+	branch = refs/heads/master
 [submodule "olefile"]
 	path = feedstocks/olefile
 	url = https://github.com/conda-forge/olefile-feedstock.git
+	branch = refs/heads/master
 [submodule "pyaml"]
 	path = feedstocks/pyaml
 	url = https://github.com/conda-forge/pyaml-feedstock.git
+	branch = refs/heads/master
 [submodule "pypdf2"]
 	path = feedstocks/pypdf2
 	url = https://github.com/conda-forge/pypdf2-feedstock.git
+	branch = refs/heads/master
 [submodule "selenium"]
 	path = feedstocks/selenium
 	url = https://github.com/conda-forge/selenium-feedstock.git
+	branch = refs/heads/master
 [submodule "speaklater"]
 	path = feedstocks/speaklater
 	url = https://github.com/conda-forge/speaklater-feedstock.git
+	branch = refs/heads/master
 [submodule "spefile"]
 	path = feedstocks/spefile
 	url = https://github.com/conda-forge/spefile-feedstock.git
+	branch = refs/heads/master
 [submodule "u3d"]
 	path = feedstocks/u3d
 	url = https://github.com/conda-forge/u3d-feedstock.git
+	branch = refs/heads/master
 [submodule "tomopy"]
 	path = feedstocks/tomopy
 	url = https://github.com/conda-forge/tomopy-feedstock.git
+	branch = refs/heads/master
 [submodule "urllib3"]
 	path = feedstocks/urllib3
 	url = https://github.com/conda-forge/urllib3-feedstock.git
+	branch = refs/heads/master
 [submodule "vtk"]
 	path = feedstocks/vtk
 	url = https://github.com/conda-forge/vtk-feedstock.git
+	branch = refs/heads/master
 [submodule "backports.functools_lru_cache"]
 	path = feedstocks/backports.functools_lru_cache
 	url = https://github.com/conda-forge/backports.functools_lru_cache-feedstock.git
+	branch = refs/heads/master
 [submodule "statsmodels"]
 	path = feedstocks/statsmodels
 	url = https://github.com/conda-forge/statsmodels-feedstock.git
+	branch = refs/heads/master
 [submodule "ws4py"]
 	path = feedstocks/ws4py
 	url = https://github.com/conda-forge/ws4py-feedstock.git
+	branch = refs/heads/master
 [submodule "prettytable"]
 	path = feedstocks/prettytable
 	url = https://github.com/conda-forge/prettytable-feedstock.git
+	branch = refs/heads/master
 [submodule "elasticsearch"]
 	path = feedstocks/elasticsearch
 	url = https://github.com/conda-forge/elasticsearch-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8"]
 	path = feedstocks/flake8
 	url = https://github.com/conda-forge/flake8-feedstock.git
+	branch = refs/heads/master
 [submodule "humanize"]
 	path = feedstocks/humanize
 	url = https://github.com/conda-forge/humanize-feedstock.git
+	branch = refs/heads/master
 [submodule "mccabe"]
 	path = feedstocks/mccabe
 	url = https://github.com/conda-forge/mccabe-feedstock.git
+	branch = refs/heads/master
 [submodule "paste"]
 	path = feedstocks/paste
 	url = https://github.com/conda-forge/paste-feedstock.git
+	branch = refs/heads/master
 [submodule "positional"]
 	path = feedstocks/positional
 	url = https://github.com/conda-forge/positional-feedstock.git
+	branch = refs/heads/master
 [submodule "pyflakes"]
 	path = feedstocks/pyflakes
 	url = https://github.com/conda-forge/pyflakes-feedstock.git
+	branch = refs/heads/master
 [submodule "requestsexceptions"]
 	path = feedstocks/requestsexceptions
 	url = https://github.com/conda-forge/requestsexceptions-feedstock.git
+	branch = refs/heads/master
 [submodule "stevedore"]
 	path = feedstocks/stevedore
 	url = https://github.com/conda-forge/stevedore-feedstock.git
+	branch = refs/heads/master
 [submodule "cmd2"]
 	path = feedstocks/cmd2
 	url = https://github.com/conda-forge/cmd2-feedstock.git
+	branch = refs/heads/master
 [submodule "debtcollector"]
 	path = feedstocks/debtcollector
 	url = https://github.com/conda-forge/debtcollector-feedstock.git
+	branch = refs/heads/master
 [submodule "elasticsearch-dsl"]
 	path = feedstocks/elasticsearch-dsl
 	url = https://github.com/conda-forge/elasticsearch-dsl-feedstock.git
+	branch = refs/heads/master
 [submodule "jsonpointer"]
 	path = feedstocks/jsonpointer
 	url = https://github.com/conda-forge/jsonpointer-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyterlab"]
 	path = feedstocks/jupyterlab
 	url = https://github.com/conda-forge/jupyterlab-feedstock.git
+	branch = refs/heads/master
 [submodule "keystoneauth1"]
 	path = feedstocks/keystoneauth1
 	url = https://github.com/conda-forge/keystoneauth1-feedstock.git
+	branch = refs/heads/master
 [submodule "netifaces"]
 	path = feedstocks/netifaces
 	url = https://github.com/conda-forge/netifaces-feedstock.git
+	branch = refs/heads/master
 [submodule "nosexcover"]
 	path = feedstocks/nosexcover
 	url = https://github.com/conda-forge/nosexcover-feedstock.git
+	branch = refs/heads/master
 [submodule "pthreads-win32"]
 	path = feedstocks/pthreads-win32
 	url = https://github.com/conda-forge/pthreads-win32-feedstock.git
+	branch = refs/heads/master
 [submodule "python-mimeparse"]
 	path = feedstocks/python-mimeparse
 	url = https://github.com/conda-forge/python-mimeparse-feedstock.git
+	branch = refs/heads/master
 [submodule "rfc3986"]
 	path = feedstocks/rfc3986
 	url = https://github.com/conda-forge/rfc3986-feedstock.git
+	branch = refs/heads/master
 [submodule "atom"]
 	path = feedstocks/atom
 	url = https://github.com/conda-forge/atom-feedstock.git
+	branch = refs/heads/master
 [submodule "avro"]
 	path = feedstocks/avro
 	url = https://github.com/conda-forge/avro-feedstock.git
+	branch = refs/heads/master
 [submodule "backports_abc"]
 	path = feedstocks/backports_abc
 	url = https://github.com/conda-forge/backports_abc-feedstock.git
+	branch = refs/heads/master
 [submodule "clyent"]
 	path = feedstocks/clyent
 	url = https://github.com/conda-forge/clyent-feedstock.git
+	branch = refs/heads/master
 [submodule "cotire"]
 	path = feedstocks/cotire
 	url = https://github.com/conda-forge/cotire-feedstock.git
+	branch = refs/heads/master
 [submodule "cyavro"]
 	path = feedstocks/cyavro
 	url = https://github.com/conda-forge/cyavro-feedstock.git
+	branch = refs/heads/master
 [submodule "extras"]
 	path = feedstocks/extras
 	url = https://github.com/conda-forge/extras-feedstock.git
+	branch = refs/heads/master
 [submodule "fabio"]
 	path = feedstocks/fabio
 	url = https://github.com/conda-forge/fabio-feedstock.git
+	branch = refs/heads/master
 [submodule "filelock"]
 	path = feedstocks/filelock
 	url = https://github.com/conda-forge/filelock-feedstock.git
+	branch = refs/heads/master
 [submodule "funcsigs"]
 	path = feedstocks/funcsigs
 	url = https://github.com/conda-forge/funcsigs-feedstock.git
+	branch = refs/heads/master
 [submodule "gdcm"]
 	path = feedstocks/gdcm
 	url = https://github.com/conda-forge/gdcm-feedstock.git
+	branch = refs/heads/master
 [submodule "gmpy2"]
 	path = feedstocks/gmpy2
 	url = https://github.com/conda-forge/gmpy2-feedstock.git
+	branch = refs/heads/master
 [submodule "isort"]
 	path = feedstocks/isort
 	url = https://github.com/conda-forge/isort-feedstock.git
+	branch = refs/heads/master
 [submodule "json-rpc"]
 	path = feedstocks/json-rpc
 	url = https://github.com/conda-forge/json-rpc-feedstock.git
+	branch = refs/heads/master
 [submodule "jsonpatch"]
 	path = feedstocks/jsonpatch
 	url = https://github.com/conda-forge/jsonpatch-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_contrib_core"]
 	path = feedstocks/jupyter_contrib_core
 	url = https://github.com/conda-forge/jupyter_contrib_core-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_nbextensions_configurator"]
 	path = feedstocks/jupyter_nbextensions_configurator
 	url = https://github.com/conda-forge/jupyter_nbextensions_configurator-feedstock.git
+	branch = refs/heads/master
 [submodule "kiwisolver"]
 	path = feedstocks/kiwisolver
 	url = https://github.com/conda-forge/kiwisolver-feedstock.git
+	branch = refs/heads/master
 [submodule "libdap4"]
 	path = feedstocks/libdap4
 	url = https://github.com/conda-forge/libdap4-feedstock.git
+	branch = refs/heads/master
 [submodule "nc_time_axis"]
 	path = feedstocks/nc_time_axis
 	url = https://github.com/conda-forge/nc_time_axis-feedstock.git
+	branch = refs/heads/master
 [submodule "netaddr"]
 	path = feedstocks/netaddr
 	url = https://github.com/conda-forge/netaddr-feedstock.git
+	branch = refs/heads/master
 [submodule "openstacksdk"]
 	path = feedstocks/openstacksdk
 	url = https://github.com/conda-forge/openstacksdk-feedstock.git
+	branch = refs/heads/master
 [submodule "os-client-config"]
 	path = feedstocks/os-client-config
 	url = https://github.com/conda-forge/os-client-config-feedstock.git
+	branch = refs/heads/master
 [submodule "peewee"]
 	path = feedstocks/peewee
 	url = https://github.com/conda-forge/peewee-feedstock.git
+	branch = refs/heads/master
 [submodule "pep257"]
 	path = feedstocks/pep257
 	url = https://github.com/conda-forge/pep257-feedstock.git
+	branch = refs/heads/master
 [submodule "pims"]
 	path = feedstocks/pims
 	url = https://github.com/conda-forge/pims-feedstock.git
+	branch = refs/heads/master
 [submodule "pydocstyle"]
 	path = feedstocks/pydocstyle
 	url = https://github.com/conda-forge/pydocstyle-feedstock.git
+	branch = refs/heads/master
 [submodule "pymongo"]
 	path = feedstocks/pymongo
 	url = https://github.com/conda-forge/pymongo-feedstock.git
+	branch = refs/heads/master
 [submodule "pypolyagamma"]
 	path = feedstocks/pypolyagamma
 	url = https://github.com/conda-forge/pypolyagamma-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest"]
 	path = feedstocks/pytest
 	url = https://github.com/conda-forge/pytest-feedstock.git
+	branch = refs/heads/master
 [submodule "python-avro"]
 	path = feedstocks/python-avro
 	url = https://github.com/conda-forge/python-avro-feedstock.git
+	branch = refs/heads/master
 [submodule "python-editor"]
 	path = feedstocks/python-editor
 	url = https://github.com/conda-forge/python-editor-feedstock.git
+	branch = refs/heads/master
 [submodule "python-snappy"]
 	path = feedstocks/python-snappy
 	url = https://github.com/conda-forge/python-snappy-feedstock.git
+	branch = refs/heads/master
 [submodule "redis-py"]
 	path = feedstocks/redis-py
 	url = https://github.com/conda-forge/redis-py-feedstock.git
+	branch = refs/heads/master
 [submodule "singledispatch"]
 	path = feedstocks/singledispatch
 	url = https://github.com/conda-forge/singledispatch-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx-bootstrap-theme"]
 	path = feedstocks/sphinx-bootstrap-theme
 	url = https://github.com/conda-forge/sphinx-bootstrap-theme-feedstock.git
+	branch = refs/heads/master
 [submodule "tzlocal"]
 	path = feedstocks/tzlocal
 	url = https://github.com/conda-forge/tzlocal-feedstock.git
+	branch = refs/heads/master
 [submodule "warlock"]
 	path = feedstocks/warlock
 	url = https://github.com/conda-forge/warlock-feedstock.git
+	branch = refs/heads/master
 [submodule "alembic"]
 	path = feedstocks/alembic
 	url = https://github.com/conda-forge/alembic-feedstock.git
+	branch = refs/heads/master
 [submodule "chartkick"]
 	path = feedstocks/chartkick
 	url = https://github.com/conda-forge/chartkick-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-cache"]
 	path = feedstocks/flask-cache
 	url = https://github.com/conda-forge/flask-cache-feedstock.git
+	branch = refs/heads/master
 [submodule "gunicorn"]
 	path = feedstocks/gunicorn
 	url = https://github.com/conda-forge/gunicorn-feedstock.git
+	branch = refs/heads/master
 [submodule "rq"]
 	path = feedstocks/rq
 	url = https://github.com/conda-forge/rq-feedstock.git
+	branch = refs/heads/master
 [submodule "sklearn-contrib-lightning"]
 	path = feedstocks/sklearn-contrib-lightning
 	url = https://github.com/conda-forge/sklearn-contrib-lightning-feedstock.git
+	branch = refs/heads/master
 [submodule "xerces-c"]
 	path = feedstocks/xerces-c
 	url = https://github.com/conda-forge/xerces-c-feedstock.git
+	branch = refs/heads/master
 [submodule "croniter"]
 	path = feedstocks/croniter
 	url = https://github.com/conda-forge/croniter-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-babel"]
 	path = feedstocks/flask-babel
 	url = https://github.com/conda-forge/flask-babel-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-wtf"]
 	path = feedstocks/flask-wtf
 	url = https://github.com/conda-forge/flask-wtf-feedstock.git
+	branch = refs/heads/master
 [submodule "flexx"]
 	path = feedstocks/flexx
 	url = https://github.com/conda-forge/flexx-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-faulthandler"]
 	path = feedstocks/pytest-faulthandler
 	url = https://github.com/conda-forge/pytest-faulthandler-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-mock"]
 	path = feedstocks/pytest-mock
 	url = https://github.com/conda-forge/pytest-mock-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-qt"]
 	path = feedstocks/pytest-qt
 	url = https://github.com/conda-forge/pytest-qt-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-xdist"]
 	path = feedstocks/pytest-xdist
 	url = https://github.com/conda-forge/pytest-xdist-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-babelex"]
 	path = feedstocks/flask-babelex
 	url = https://github.com/conda-forge/flask-babelex-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-bcrypt"]
 	path = feedstocks/flask-bcrypt
 	url = https://github.com/conda-forge/flask-bcrypt-feedstock.git
+	branch = refs/heads/master
 [submodule "mako"]
 	path = feedstocks/mako
 	url = https://github.com/conda-forge/mako-feedstock.git
+	branch = refs/heads/master
 [submodule "srtm.py"]
 	path = feedstocks/srtm.py
 	url = https://github.com/conda-forge/srtm.py-feedstock.git
+	branch = refs/heads/master
 [submodule "jmespath"]
 	path = feedstocks/jmespath
 	url = https://github.com/conda-forge/jmespath-feedstock.git
+	branch = refs/heads/master
 [submodule "pyferret"]
 	path = feedstocks/pyferret
 	url = https://github.com/conda-forge/pyferret-feedstock.git
+	branch = refs/heads/master
 [submodule "s3transfer"]
 	path = feedstocks/s3transfer
 	url = https://github.com/conda-forge/s3transfer-feedstock.git
+	branch = refs/heads/master
 [submodule "qwt"]
 	path = feedstocks/qwt
 	url = https://github.com/conda-forge/qwt-feedstock.git
+	branch = refs/heads/master
 [submodule "qwtpolar"]
 	path = feedstocks/qwtpolar
 	url = https://github.com/conda-forge/qwtpolar-feedstock.git
+	branch = refs/heads/master
 [submodule "reproject"]
 	path = feedstocks/reproject
 	url = https://github.com/conda-forge/reproject-feedstock.git
+	branch = refs/heads/master
 [submodule "botocore"]
 	path = feedstocks/botocore
 	url = https://github.com/conda-forge/botocore-feedstock.git
+	branch = refs/heads/master
 [submodule "docutils"]
 	path = feedstocks/docutils
 	url = https://github.com/conda-forge/docutils-feedstock.git
+	branch = refs/heads/master
 [submodule "ipython_genutils"]
 	path = feedstocks/ipython_genutils
 	url = https://github.com/conda-forge/ipython_genutils-feedstock.git
+	branch = refs/heads/master
 [submodule "postgresql"]
 	path = feedstocks/postgresql
 	url = https://github.com/conda-forge/postgresql-feedstock.git
+	branch = refs/heads/master
 [submodule "alabaster"]
 	path = feedstocks/alabaster
 	url = https://github.com/conda-forge/alabaster-feedstock.git
+	branch = refs/heads/master
 [submodule "win_unicode_console"]
 	path = feedstocks/win_unicode_console
 	url = https://github.com/conda-forge/win_unicode_console-feedstock.git
+	branch = refs/heads/master
 [submodule "awscli"]
 	path = feedstocks/awscli
 	url = https://github.com/conda-forge/awscli-feedstock.git
+	branch = refs/heads/master
 [submodule "bob.ip.flandmark"]
 	path = feedstocks/bob.ip.flandmark
 	url = https://github.com/conda-forge/bob.ip.flandmark-feedstock.git
+	branch = refs/heads/master
 [submodule "cythongsl"]
 	path = feedstocks/cythongsl
 	url = https://github.com/conda-forge/cythongsl-feedstock.git
+	branch = refs/heads/master
 [submodule "filechunkio"]
 	path = feedstocks/filechunkio
 	url = https://github.com/conda-forge/filechunkio-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-login"]
 	path = feedstocks/flask-login
 	url = https://github.com/conda-forge/flask-login-feedstock.git
+	branch = refs/heads/master
 [submodule "future"]
 	path = feedstocks/future
 	url = https://github.com/conda-forge/future-feedstock.git
+	branch = refs/heads/master
 [submodule "jansson"]
 	path = feedstocks/jansson
 	url = https://github.com/conda-forge/jansson-feedstock.git
+	branch = refs/heads/master
 [submodule "oauthlib"]
 	path = feedstocks/oauthlib
 	url = https://github.com/conda-forge/oauthlib-feedstock.git
+	branch = refs/heads/master
 [submodule "pydruid"]
 	path = feedstocks/pydruid
 	url = https://github.com/conda-forge/pydruid-feedstock.git
+	branch = refs/heads/master
 [submodule "python-levenshtein"]
 	path = feedstocks/python-levenshtein
 	url = https://github.com/conda-forge/python-levenshtein-feedstock.git
+	branch = refs/heads/master
 [submodule "rsa"]
 	path = feedstocks/rsa
 	url = https://github.com/conda-forge/rsa-feedstock.git
+	branch = refs/heads/master
 [submodule "setuptools-git"]
 	path = feedstocks/setuptools-git
 	url = https://github.com/conda-forge/setuptools-git-feedstock.git
+	branch = refs/heads/master
 [submodule "snakefood"]
 	path = feedstocks/snakefood
 	url = https://github.com/conda-forge/snakefood-feedstock.git
+	branch = refs/heads/master
 [submodule "sortedcontainers"]
 	path = feedstocks/sortedcontainers
 	url = https://github.com/conda-forge/sortedcontainers-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx-argparse"]
 	path = feedstocks/sphinx-argparse
 	url = https://github.com/conda-forge/sphinx-argparse-feedstock.git
+	branch = refs/heads/master
 [submodule "tlslite"]
 	path = feedstocks/tlslite
 	url = https://github.com/conda-forge/tlslite-feedstock.git
+	branch = refs/heads/master
 [submodule "websocket-client"]
 	path = feedstocks/websocket-client
 	url = https://github.com/conda-forge/websocket-client-feedstock.git
+	branch = refs/heads/master
 [submodule "oauth2client"]
 	path = feedstocks/oauth2client
 	url = https://github.com/conda-forge/oauth2client-feedstock.git
+	branch = refs/heads/master
 [submodule "requests-oauthlib"]
 	path = feedstocks/requests-oauthlib
 	url = https://github.com/conda-forge/requests-oauthlib-feedstock.git
+	branch = refs/heads/master
 [submodule "setuptools"]
 	path = feedstocks/setuptools
 	url = https://github.com/conda-forge/setuptools-feedstock.git
+	branch = refs/heads/master
 [submodule "altair"]
 	path = feedstocks/altair
 	url = https://github.com/conda-forge/altair-feedstock.git
+	branch = refs/heads/master
 [submodule "click"]
 	path = feedstocks/click
 	url = https://github.com/conda-forge/click-feedstock.git
+	branch = refs/heads/master
 [submodule "cliff"]
 	path = feedstocks/cliff
 	url = https://github.com/conda-forge/cliff-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-oauthlib"]
 	path = feedstocks/flask-oauthlib
 	url = https://github.com/conda-forge/flask-oauthlib-feedstock.git
+	branch = refs/heads/master
 [submodule "fuzzywuzzy"]
 	path = feedstocks/fuzzywuzzy
 	url = https://github.com/conda-forge/fuzzywuzzy-feedstock.git
+	branch = refs/heads/master
 [submodule "inflection"]
 	path = feedstocks/inflection
 	url = https://github.com/conda-forge/inflection-feedstock.git
+	branch = refs/heads/master
 [submodule "mpich"]
 	path = feedstocks/mpich
 	url = https://github.com/conda-forge/mpich-feedstock.git
+	branch = refs/heads/master
 [submodule "pyjwt"]
 	path = feedstocks/pyjwt
 	url = https://github.com/conda-forge/pyjwt-feedstock.git
+	branch = refs/heads/master
 [submodule "spylon"]
 	path = feedstocks/spylon
 	url = https://github.com/conda-forge/spylon-feedstock.git
+	branch = refs/heads/master
 [submodule "swig"]
 	path = feedstocks/swig
 	url = https://github.com/conda-forge/swig-feedstock.git
+	branch = refs/heads/master
 [submodule "tangelo"]
 	path = feedstocks/tangelo
 	url = https://github.com/conda-forge/tangelo-feedstock.git
+	branch = refs/heads/master
 [submodule "uritemplate"]
 	path = feedstocks/uritemplate
 	url = https://github.com/conda-forge/uritemplate-feedstock.git
+	branch = refs/heads/master
 [submodule "fake-factory"]
 	path = feedstocks/fake-factory
 	url = https://github.com/conda-forge/fake-factory-feedstock.git
+	branch = refs/heads/master
 [submodule "ferret_datasets"]
 	path = feedstocks/ferret_datasets
 	url = https://github.com/conda-forge/ferret_datasets-feedstock.git
+	branch = refs/heads/master
 [submodule "inkscape"]
 	path = feedstocks/inkscape
 	url = https://github.com/conda-forge/inkscape-feedstock.git
+	branch = refs/heads/master
 [submodule "libgfortran"]
 	path = feedstocks/libgfortran
 	url = https://github.com/conda-forge/libgfortran-feedstock.git
+	branch = refs/heads/master
 [submodule "pydy"]
 	path = feedstocks/pydy
 	url = https://github.com/conda-forge/pydy-feedstock.git
+	branch = refs/heads/master
 [submodule "pytrie"]
 	path = feedstocks/pytrie
 	url = https://github.com/conda-forge/pytrie-feedstock.git
+	branch = refs/heads/master
 [submodule "subprocess32"]
 	path = feedstocks/subprocess32
 	url = https://github.com/conda-forge/subprocess32-feedstock.git
+	branch = refs/heads/master
 [submodule "hachoir-core"]
 	path = feedstocks/hachoir-core
 	url = https://github.com/conda-forge/hachoir-core-feedstock.git
+	branch = refs/heads/master
 [submodule "htmlmin"]
 	path = feedstocks/htmlmin
 	url = https://github.com/conda-forge/htmlmin-feedstock.git
+	branch = refs/heads/master
 [submodule "hyperspy"]
 	path = feedstocks/hyperspy
 	url = https://github.com/conda-forge/hyperspy-feedstock.git
+	branch = refs/heads/master
 [submodule "jsmin"]
 	path = feedstocks/jsmin
 	url = https://github.com/conda-forge/jsmin-feedstock.git
+	branch = refs/heads/master
 [submodule "mss"]
 	path = feedstocks/mss
 	url = https://github.com/conda-forge/mss-feedstock.git
+	branch = refs/heads/master
 [submodule "pyglet"]
 	path = feedstocks/pyglet
 	url = https://github.com/conda-forge/pyglet-feedstock.git
+	branch = refs/heads/master
 [submodule "pysal"]
 	path = feedstocks/pysal
 	url = https://github.com/conda-forge/pysal-feedstock.git
+	branch = refs/heads/master
 [submodule "pip"]
 	path = feedstocks/pip
 	url = https://github.com/conda-forge/pip-feedstock.git
+	branch = refs/heads/master
 [submodule "pylibmc"]
 	path = feedstocks/pylibmc
 	url = https://github.com/conda-forge/pylibmc-feedstock.git
+	branch = refs/heads/master
 [submodule "resampy"]
 	path = feedstocks/resampy
 	url = https://github.com/conda-forge/resampy-feedstock.git
+	branch = refs/heads/master
 [submodule "wincertstore"]
 	path = feedstocks/wincertstore
 	url = https://github.com/conda-forge/wincertstore-feedstock.git
+	branch = refs/heads/master
 [submodule "apscheduler"]
 	path = feedstocks/apscheduler
 	url = https://github.com/conda-forge/apscheduler-feedstock.git
+	branch = refs/heads/master
 [submodule "audioread"]
 	path = feedstocks/audioread
 	url = https://github.com/conda-forge/audioread-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-env"]
 	path = feedstocks/conda-env
 	url = https://github.com/conda-forge/conda-env-feedstock.git
+	branch = refs/heads/master
 [submodule "hachoir-parser"]
 	path = feedstocks/hachoir-parser
 	url = https://github.com/conda-forge/hachoir-parser-feedstock.git
+	branch = refs/heads/master
 [submodule "nipype"]
 	path = feedstocks/nipype
 	url = https://github.com/conda-forge/nipype-feedstock.git
+	branch = refs/heads/master
 [submodule "pango"]
 	path = feedstocks/pango
 	url = https://github.com/conda-forge/pango-feedstock.git
+	branch = refs/heads/master
 [submodule "prov"]
 	path = feedstocks/prov
 	url = https://github.com/conda-forge/prov-feedstock.git
+	branch = refs/heads/master
 [submodule "pydotplus"]
 	path = feedstocks/pydotplus
 	url = https://github.com/conda-forge/pydotplus-feedstock.git
+	branch = refs/heads/master
 [submodule "wheel"]
 	path = feedstocks/wheel
 	url = https://github.com/conda-forge/wheel-feedstock.git
+	branch = refs/heads/master
 [submodule "xvfbwrapper"]
 	path = feedstocks/xvfbwrapper
 	url = https://github.com/conda-forge/xvfbwrapper-feedstock.git
+	branch = refs/heads/master
 [submodule "channelarchiver"]
 	path = feedstocks/channelarchiver
 	url = https://github.com/conda-forge/channelarchiver-feedstock.git
+	branch = refs/heads/master
 [submodule "librosa"]
 	path = feedstocks/librosa
 	url = https://github.com/conda-forge/librosa-feedstock.git
+	branch = refs/heads/master
 [submodule "qt"]
 	path = feedstocks/qt
 	url = https://github.com/conda-forge/qt-feedstock.git
+	branch = refs/heads/master
 [submodule "rasterstats"]
 	path = feedstocks/rasterstats
 	url = https://github.com/conda-forge/rasterstats-feedstock.git
+	branch = refs/heads/master
 [submodule "sparsehash"]
 	path = feedstocks/sparsehash
 	url = https://github.com/conda-forge/sparsehash-feedstock.git
+	branch = refs/heads/master
 [submodule "gperf"]
 	path = feedstocks/gperf
 	url = https://github.com/conda-forge/gperf-feedstock.git
+	branch = refs/heads/master
 [submodule "iverilog"]
 	path = feedstocks/iverilog
 	url = https://github.com/conda-forge/iverilog-feedstock.git
+	branch = refs/heads/master
 [submodule "sed"]
 	path = feedstocks/sed
 	url = https://github.com/conda-forge/sed-feedstock.git
+	branch = refs/heads/master
 [submodule "cairomm"]
 	path = feedstocks/cairomm
 	url = https://github.com/conda-forge/cairomm-feedstock.git
+	branch = refs/heads/master
 [submodule "hachoir-metadata"]
 	path = feedstocks/hachoir-metadata
 	url = https://github.com/conda-forge/hachoir-metadata-feedstock.git
+	branch = refs/heads/master
 [submodule "iso8601"]
 	path = feedstocks/iso8601
 	url = https://github.com/conda-forge/iso8601-feedstock.git
+	branch = refs/heads/master
 [submodule "metafone"]
 	path = feedstocks/metafone
 	url = https://github.com/conda-forge/metafone-feedstock.git
+	branch = refs/heads/master
 [submodule "probableparsing"]
 	path = feedstocks/probableparsing
 	url = https://github.com/conda-forge/probableparsing-feedstock.git
+	branch = refs/heads/master
 [submodule "python-crfsuite"]
 	path = feedstocks/python-crfsuite
 	url = https://github.com/conda-forge/python-crfsuite-feedstock.git
+	branch = refs/heads/master
 [submodule "usaddress"]
 	path = feedstocks/usaddress
 	url = https://github.com/conda-forge/usaddress-feedstock.git
+	branch = refs/heads/master
 [submodule "zwatershed"]
 	path = feedstocks/zwatershed
 	url = https://github.com/conda-forge/zwatershed-feedstock.git
+	branch = refs/heads/master
 [submodule "catimg"]
 	path = feedstocks/catimg
 	url = https://github.com/conda-forge/catimg-feedstock.git
+	branch = refs/heads/master
 [submodule "diskcache"]
 	path = feedstocks/diskcache
 	url = https://github.com/conda-forge/diskcache-feedstock.git
+	branch = refs/heads/master
 [submodule "hiveplot"]
 	path = feedstocks/hiveplot
 	url = https://github.com/conda-forge/hiveplot-feedstock.git
+	branch = refs/heads/master
 [submodule "imgurpython"]
 	path = feedstocks/imgurpython
 	url = https://github.com/conda-forge/imgurpython-feedstock.git
+	branch = refs/heads/master
 [submodule "iterm2-tools"]
 	path = feedstocks/iterm2-tools
 	url = https://github.com/conda-forge/iterm2-tools-feedstock.git
+	branch = refs/heads/master
 [submodule "prefsync"]
 	path = feedstocks/prefsync
 	url = https://github.com/conda-forge/prefsync-feedstock.git
+	branch = refs/heads/master
 [submodule "addict"]
 	path = feedstocks/addict
 	url = https://github.com/conda-forge/addict-feedstock.git
+	branch = refs/heads/master
 [submodule "asyncssh"]
 	path = feedstocks/asyncssh
 	url = https://github.com/conda-forge/asyncssh-feedstock.git
+	branch = refs/heads/master
 [submodule "capturer"]
 	path = feedstocks/capturer
 	url = https://github.com/conda-forge/capturer-feedstock.git
+	branch = refs/heads/master
 [submodule "coloredlogs"]
 	path = feedstocks/coloredlogs
 	url = https://github.com/conda-forge/coloredlogs-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-workon"]
 	path = feedstocks/conda-workon
 	url = https://github.com/conda-forge/conda-workon-feedstock.git
+	branch = refs/heads/master
 [submodule "girder-client"]
 	path = feedstocks/girder-client
 	url = https://github.com/conda-forge/girder-client-feedstock.git
+	branch = refs/heads/master
 [submodule "hdbscan"]
 	path = feedstocks/hdbscan
 	url = https://github.com/conda-forge/hdbscan-feedstock.git
+	branch = refs/heads/master
 [submodule "humanfriendly"]
 	path = feedstocks/humanfriendly
 	url = https://github.com/conda-forge/humanfriendly-feedstock.git
+	branch = refs/heads/master
 [submodule "ipdb"]
 	path = feedstocks/ipdb
 	url = https://github.com/conda-forge/ipdb-feedstock.git
+	branch = refs/heads/master
 [submodule "simbody"]
 	path = feedstocks/simbody
 	url = https://github.com/conda-forge/simbody-feedstock.git
+	branch = refs/heads/master
 [submodule "structlog"]
 	path = feedstocks/structlog
 	url = https://github.com/conda-forge/structlog-feedstock.git
+	branch = refs/heads/master
 [submodule "theano"]
 	path = feedstocks/theano
 	url = https://github.com/conda-forge/theano-feedstock.git
+	branch = refs/heads/master
 [submodule "verboselogs"]
 	path = feedstocks/verboselogs
 	url = https://github.com/conda-forge/verboselogs-feedstock.git
+	branch = refs/heads/master
 [submodule "voluptuous"]
 	path = feedstocks/voluptuous
 	url = https://github.com/conda-forge/voluptuous-feedstock.git
+	branch = refs/heads/master
 [submodule "anaconda-verify"]
 	path = feedstocks/anaconda-verify
 	url = https://github.com/conda-forge/anaconda-verify-feedstock.git
+	branch = refs/heads/master
 [submodule "docker-py"]
 	path = feedstocks/docker-py
 	url = https://github.com/conda-forge/docker-py-feedstock.git
+	branch = refs/heads/master
 [submodule "girder"]
 	path = feedstocks/girder
 	url = https://github.com/conda-forge/girder-feedstock.git
+	branch = refs/heads/master
 [submodule "google-api-python-client"]
 	path = feedstocks/google-api-python-client
 	url = https://github.com/conda-forge/google-api-python-client-feedstock.git
+	branch = refs/heads/master
 [submodule "jsanimation"]
 	path = feedstocks/jsanimation
 	url = https://github.com/conda-forge/jsanimation-feedstock.git
+	branch = refs/heads/master
 [submodule "ua-parser"]
 	path = feedstocks/ua-parser
 	url = https://github.com/conda-forge/ua-parser-feedstock.git
+	branch = refs/heads/master
 [submodule "anypytools"]
 	path = feedstocks/anypytools
 	url = https://github.com/conda-forge/anypytools-feedstock.git
+	branch = refs/heads/master
 [submodule "pydoe"]
 	path = feedstocks/pydoe
 	url = https://github.com/conda-forge/pydoe-feedstock.git
+	branch = refs/heads/master
 [submodule "pyinstaller"]
 	path = feedstocks/pyinstaller
 	url = https://github.com/conda-forge/pyinstaller-feedstock.git
+	branch = refs/heads/master
 [submodule "waf"]
 	path = feedstocks/waf
 	url = https://github.com/conda-forge/waf-feedstock.git
+	branch = refs/heads/master
 [submodule "asciitree"]
 	path = feedstocks/asciitree
 	url = https://github.com/conda-forge/asciitree-feedstock.git
+	branch = refs/heads/master
 [submodule "hypothesis"]
 	path = feedstocks/hypothesis
 	url = https://github.com/conda-forge/hypothesis-feedstock.git
+	branch = refs/heads/master
 [submodule "joblib"]
 	path = feedstocks/joblib
 	url = https://github.com/conda-forge/joblib-feedstock.git
+	branch = refs/heads/master
 [submodule "lazyasd"]
 	path = feedstocks/lazyasd
 	url = https://github.com/conda-forge/lazyasd-feedstock.git
+	branch = refs/heads/master
 [submodule "scandir"]
 	path = feedstocks/scandir
 	url = https://github.com/conda-forge/scandir-feedstock.git
+	branch = refs/heads/master
 [submodule "anaconda-client"]
 	path = feedstocks/anaconda-client
 	url = https://github.com/conda-forge/anaconda-client-feedstock.git
+	branch = refs/heads/master
 [submodule "branca"]
 	path = feedstocks/branca
 	url = https://github.com/conda-forge/branca-feedstock.git
+	branch = refs/heads/master
 [submodule "f90wrap"]
 	path = feedstocks/f90wrap
 	url = https://github.com/conda-forge/f90wrap-feedstock.git
+	branch = refs/heads/master
 [submodule "libconda"]
 	path = feedstocks/libconda
 	url = https://github.com/conda-forge/libconda-feedstock.git
+	branch = refs/heads/master
 [submodule "orange3"]
 	path = feedstocks/orange3
 	url = https://github.com/conda-forge/orange3-feedstock.git
+	branch = refs/heads/master
 [submodule "pyfive"]
 	path = feedstocks/pyfive
 	url = https://github.com/conda-forge/pyfive-feedstock.git
+	branch = refs/heads/master
 [submodule "ruamel_yaml"]
 	path = feedstocks/ruamel_yaml
 	url = https://github.com/conda-forge/ruamel_yaml-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-bio"]
 	path = feedstocks/scikit-bio
 	url = https://github.com/conda-forge/scikit-bio-feedstock.git
+	branch = refs/heads/master
 [submodule "mtspec"]
 	path = feedstocks/mtspec
 	url = https://github.com/conda-forge/mtspec-feedstock.git
+	branch = refs/heads/master
 [submodule "newrelic"]
 	path = feedstocks/newrelic
 	url = https://github.com/conda-forge/newrelic-feedstock.git
+	branch = refs/heads/master
 [submodule "python-gnupg"]
 	path = feedstocks/python-gnupg
 	url = https://github.com/conda-forge/python-gnupg-feedstock.git
+	branch = refs/heads/master
 [submodule "category_encoders"]
 	path = feedstocks/category_encoders
 	url = https://github.com/conda-forge/category_encoders-feedstock.git
+	branch = refs/heads/master
 [submodule "circleclient"]
 	path = feedstocks/circleclient
 	url = https://github.com/conda-forge/circleclient-feedstock.git
+	branch = refs/heads/master
 [submodule "pykwalify"]
 	path = feedstocks/pykwalify
 	url = https://github.com/conda-forge/pykwalify-feedstock.git
+	branch = refs/heads/master
 [submodule "emperor"]
 	path = feedstocks/emperor
 	url = https://github.com/conda-forge/emperor-feedstock.git
+	branch = refs/heads/master
 [submodule "pudb"]
 	path = feedstocks/pudb
 	url = https://github.com/conda-forge/pudb-feedstock.git
+	branch = refs/heads/master
 [submodule "slda"]
 	path = feedstocks/slda
 	url = https://github.com/conda-forge/slda-feedstock.git
+	branch = refs/heads/master
 [submodule "snakebite"]
 	path = feedstocks/snakebite
 	url = https://github.com/conda-forge/snakebite-feedstock.git
+	branch = refs/heads/master
 [submodule "nb_conda"]
 	path = feedstocks/nb_conda
 	url = https://github.com/conda-forge/nb_conda-feedstock.git
+	branch = refs/heads/master
 [submodule "qtpy"]
 	path = feedstocks/qtpy
 	url = https://github.com/conda-forge/qtpy-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-build"]
 	path = feedstocks/conda-build
 	url = https://github.com/conda-forge/conda-build-feedstock.git
+	branch = refs/heads/master
 [submodule "circleci-helpers"]
 	path = feedstocks/circleci-helpers
 	url = https://github.com/conda-forge/circleci-helpers-feedstock.git
+	branch = refs/heads/master
 [submodule "libpq"]
 	path = feedstocks/libpq
 	url = https://github.com/conda-forge/libpq-feedstock.git
+	branch = refs/heads/master
 [submodule "mercurial"]
 	path = feedstocks/mercurial
 	url = https://github.com/conda-forge/mercurial-feedstock.git
+	branch = refs/heads/master
 [submodule "psycopg2"]
 	path = feedstocks/psycopg2
 	url = https://github.com/conda-forge/psycopg2-feedstock.git
+	branch = refs/heads/master
 [submodule "pyhocon"]
 	path = feedstocks/pyhocon
 	url = https://github.com/conda-forge/pyhocon-feedstock.git
+	branch = refs/heads/master
 [submodule "qt_binder"]
 	path = feedstocks/qt_binder
 	url = https://github.com/conda-forge/qt_binder-feedstock.git
+	branch = refs/heads/master
 [submodule "pv"]
 	path = feedstocks/pv
 	url = https://github.com/conda-forge/pv-feedstock.git
+	branch = refs/heads/master
 [submodule "pyvisa"]
 	path = feedstocks/pyvisa
 	url = https://github.com/conda-forge/pyvisa-feedstock.git
+	branch = refs/heads/master
 [submodule "stack"]
 	path = feedstocks/stack
 	url = https://github.com/conda-forge/stack-feedstock.git
+	branch = refs/heads/master
 [submodule "bc"]
 	path = feedstocks/bc
 	url = https://github.com/conda-forge/bc-feedstock.git
+	branch = refs/heads/master
 [submodule "plotly"]
 	path = feedstocks/plotly
 	url = https://github.com/conda-forge/plotly-feedstock.git
+	branch = refs/heads/master
 [submodule "pymeasure"]
 	path = feedstocks/pymeasure
 	url = https://github.com/conda-forge/pymeasure-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_contrib_nbextensions"]
 	path = feedstocks/jupyter_contrib_nbextensions
 	url = https://github.com/conda-forge/jupyter_contrib_nbextensions-feedstock.git
+	branch = refs/heads/master
 [submodule "port-for"]
 	path = feedstocks/port-for
 	url = https://github.com/conda-forge/port-for-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx"]
 	path = feedstocks/sphinx
 	url = https://github.com/conda-forge/sphinx-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx_rtd_theme"]
 	path = feedstocks/sphinx_rtd_theme
 	url = https://github.com/conda-forge/sphinx_rtd_theme-feedstock.git
+	branch = refs/heads/master
 [submodule "cgal"]
 	path = feedstocks/cgal
 	url = https://github.com/conda-forge/cgal-feedstock.git
+	branch = refs/heads/master
 [submodule "importlib"]
 	path = feedstocks/importlib
 	url = https://github.com/conda-forge/importlib-feedstock.git
+	branch = refs/heads/master
 [submodule "obspy"]
 	path = feedstocks/obspy
 	url = https://github.com/conda-forge/obspy-feedstock.git
+	branch = refs/heads/master
 [submodule "ordereddict"]
 	path = feedstocks/ordereddict
 	url = https://github.com/conda-forge/ordereddict-feedstock.git
+	branch = refs/heads/master
 [submodule "path.py"]
 	path = feedstocks/path.py
 	url = https://github.com/conda-forge/path.py-feedstock.git
+	branch = refs/heads/master
 [submodule "nsis"]
 	path = feedstocks/nsis
 	url = https://github.com/conda-forge/nsis-feedstock.git
+	branch = refs/heads/master
 [submodule "pbr"]
 	path = feedstocks/pbr
 	url = https://github.com/conda-forge/pbr-feedstock.git
+	branch = refs/heads/master
 [submodule "constructor"]
 	path = feedstocks/constructor
 	url = https://github.com/conda-forge/constructor-feedstock.git
+	branch = refs/heads/master
 [submodule "statuspage"]
 	path = feedstocks/statuspage
 	url = https://github.com/conda-forge/statuspage-feedstock.git
+	branch = refs/heads/master
 [submodule "conda"]
 	path = feedstocks/conda
 	url = https://github.com/conda-forge/conda-feedstock.git
+	branch = refs/heads/master
 [submodule "pbzip2"]
 	path = feedstocks/pbzip2
 	url = https://github.com/conda-forge/pbzip2-feedstock.git
+	branch = refs/heads/master
 [submodule "autograd"]
 	path = feedstocks/autograd
 	url = https://github.com/conda-forge/autograd-feedstock.git
+	branch = refs/heads/master
 [submodule "coverage"]
 	path = feedstocks/coverage
 	url = https://github.com/conda-forge/coverage-feedstock.git
+	branch = refs/heads/master
 [submodule "pycalphad"]
 	path = feedstocks/pycalphad
 	url = https://github.com/conda-forge/pycalphad-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxcontrib-autoprogram"]
 	path = feedstocks/sphinxcontrib-autoprogram
 	url = https://github.com/conda-forge/sphinxcontrib-autoprogram-feedstock.git
+	branch = refs/heads/master
 [submodule "depfinder"]
 	path = feedstocks/depfinder
 	url = https://github.com/conda-forge/depfinder-feedstock.git
+	branch = refs/heads/master
 [submodule "django-enumfields"]
 	path = feedstocks/django-enumfields
 	url = https://github.com/conda-forge/django-enumfields-feedstock.git
+	branch = refs/heads/master
 [submodule "doctr"]
 	path = feedstocks/doctr
 	url = https://github.com/conda-forge/doctr-feedstock.git
+	branch = refs/heads/master
 [submodule "exec-wrappers"]
 	path = feedstocks/exec-wrappers
 	url = https://github.com/conda-forge/exec-wrappers-feedstock.git
+	branch = refs/heads/master
 [submodule "sound_field_analysis"]
 	path = feedstocks/sound_field_analysis
 	url = https://github.com/conda-forge/sound_field_analysis-feedstock.git
+	branch = refs/heads/master
 [submodule "stdlib-list"]
 	path = feedstocks/stdlib-list
 	url = https://github.com/conda-forge/stdlib-list-feedstock.git
+	branch = refs/heads/master
 [submodule "otsvm"]
 	path = feedstocks/otsvm
 	url = https://github.com/conda-forge/otsvm-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-beam"]
 	path = feedstocks/scikit-beam
 	url = https://github.com/conda-forge/scikit-beam-feedstock.git
+	branch = refs/heads/master
 [submodule "snowballstemmer"]
 	path = feedstocks/snowballstemmer
 	url = https://github.com/conda-forge/snowballstemmer-feedstock.git
+	branch = refs/heads/master
 [submodule "super_state_machine"]
 	path = feedstocks/super_state_machine
 	url = https://github.com/conda-forge/super_state_machine-feedstock.git
+	branch = refs/heads/master
 [submodule "testfixtures"]
 	path = feedstocks/testfixtures
 	url = https://github.com/conda-forge/testfixtures-feedstock.git
+	branch = refs/heads/master
 [submodule "wordcloud"]
 	path = feedstocks/wordcloud
 	url = https://github.com/conda-forge/wordcloud-feedstock.git
+	branch = refs/heads/master
 [submodule "dodgy"]
 	path = feedstocks/dodgy
 	url = https://github.com/conda-forge/dodgy-feedstock.git
+	branch = refs/heads/master
 [submodule "enum34"]
 	path = feedstocks/enum34
 	url = https://github.com/conda-forge/enum34-feedstock.git
+	branch = refs/heads/master
 [submodule "ipaddress"]
 	path = feedstocks/ipaddress
 	url = https://github.com/conda-forge/ipaddress-feedstock.git
+	branch = refs/heads/master
 [submodule "keras"]
 	path = feedstocks/keras
 	url = https://github.com/conda-forge/keras-feedstock.git
+	branch = refs/heads/master
 [submodule "lazy-object-proxy"]
 	path = feedstocks/lazy-object-proxy
 	url = https://github.com/conda-forge/lazy-object-proxy-feedstock.git
+	branch = refs/heads/master
 [submodule "otrobopt"]
 	path = feedstocks/otrobopt
 	url = https://github.com/conda-forge/otrobopt-feedstock.git
+	branch = refs/heads/master
 [submodule "pies"]
 	path = feedstocks/pies
 	url = https://github.com/conda-forge/pies-feedstock.git
+	branch = refs/heads/master
 [submodule "pies2overrides"]
 	path = feedstocks/pies2overrides
 	url = https://github.com/conda-forge/pies2overrides-feedstock.git
+	branch = refs/heads/master
 [submodule "pyroma"]
 	path = feedstocks/pyroma
 	url = https://github.com/conda-forge/pyroma-feedstock.git
+	branch = refs/heads/master
 [submodule "setoptconf"]
 	path = feedstocks/setoptconf
 	url = https://github.com/conda-forge/setoptconf-feedstock.git
+	branch = refs/heads/master
 [submodule "vulture"]
 	path = feedstocks/vulture
 	url = https://github.com/conda-forge/vulture-feedstock.git
+	branch = refs/heads/master
 [submodule "wrapt"]
 	path = feedstocks/wrapt
 	url = https://github.com/conda-forge/wrapt-feedstock.git
+	branch = refs/heads/master
 [submodule "xray-vision"]
 	path = feedstocks/xray-vision
 	url = https://github.com/conda-forge/xray-vision-feedstock.git
+	branch = refs/heads/master
 [submodule "legit"]
 	path = feedstocks/legit
 	url = https://github.com/conda-forge/legit-feedstock.git
+	branch = refs/heads/master
 [submodule "attrdict"]
 	path = feedstocks/attrdict
 	url = https://github.com/conda-forge/attrdict-feedstock.git
+	branch = refs/heads/master
 [submodule "feedstockrot"]
 	path = feedstocks/feedstockrot
 	url = https://github.com/conda-forge/feedstockrot-feedstock.git
+	branch = refs/heads/master
 [submodule "imagesize"]
 	path = feedstocks/imagesize
 	url = https://github.com/conda-forge/imagesize-feedstock.git
+	branch = refs/heads/master
 [submodule "numexpr"]
 	path = feedstocks/numexpr
 	url = https://github.com/conda-forge/numexpr-feedstock.git
+	branch = refs/heads/master
 [submodule "patsy"]
 	path = feedstocks/patsy
 	url = https://github.com/conda-forge/patsy-feedstock.git
+	branch = refs/heads/master
 [submodule "pdfminer"]
 	path = feedstocks/pdfminer
 	url = https://github.com/conda-forge/pdfminer-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-sftpserver"]
 	path = feedstocks/pytest-sftpserver
 	url = https://github.com/conda-forge/pytest-sftpserver-feedstock.git
+	branch = refs/heads/master
 [submodule "python-docx"]
 	path = feedstocks/python-docx
 	url = https://github.com/conda-forge/python-docx-feedstock.git
+	branch = refs/heads/master
 [submodule "python-pptx"]
 	path = feedstocks/python-pptx
 	url = https://github.com/conda-forge/python-pptx-feedstock.git
+	branch = refs/heads/master
 [submodule "quantecon"]
 	path = feedstocks/quantecon
 	url = https://github.com/conda-forge/quantecon-feedstock.git
+	branch = refs/heads/master
 [submodule "seaborn"]
 	path = feedstocks/seaborn
 	url = https://github.com/conda-forge/seaborn-feedstock.git
+	branch = refs/heads/master
 [submodule "aniso8601"]
 	path = feedstocks/aniso8601
 	url = https://github.com/conda-forge/aniso8601-feedstock.git
+	branch = refs/heads/master
 [submodule "cssselect"]
 	path = feedstocks/cssselect
 	url = https://github.com/conda-forge/cssselect-feedstock.git
+	branch = refs/heads/master
 [submodule "cssutils"]
 	path = feedstocks/cssutils
 	url = https://github.com/conda-forge/cssutils-feedstock.git
+	branch = refs/heads/master
 [submodule "harfbuzz"]
 	path = feedstocks/harfbuzz
 	url = https://github.com/conda-forge/harfbuzz-feedstock.git
+	branch = refs/heads/master
 [submodule "linecache2"]
 	path = feedstocks/linecache2
 	url = https://github.com/conda-forge/linecache2-feedstock.git
+	branch = refs/heads/master
 [submodule "premailer"]
 	path = feedstocks/premailer
 	url = https://github.com/conda-forge/premailer-feedstock.git
+	branch = refs/heads/master
 [submodule "pytables"]
 	path = feedstocks/pytables
 	url = https://github.com/conda-forge/pytables-feedstock.git
+	branch = refs/heads/master
 [submodule "python-marisa-trie"]
 	path = feedstocks/python-marisa-trie
 	url = https://github.com/conda-forge/python-marisa-trie-feedstock.git
+	branch = refs/heads/master
 [submodule "qds-sdk"]
 	path = feedstocks/qds-sdk
 	url = https://github.com/conda-forge/qds-sdk-feedstock.git
+	branch = refs/heads/master
 [submodule "slackclient"]
 	path = feedstocks/slackclient
 	url = https://github.com/conda-forge/slackclient-feedstock.git
+	branch = refs/heads/master
 [submodule "speechrecognition"]
 	path = feedstocks/speechrecognition
 	url = https://github.com/conda-forge/speechrecognition-feedstock.git
+	branch = refs/heads/master
 [submodule "user-agents"]
 	path = feedstocks/user-agents
 	url = https://github.com/conda-forge/user-agents-feedstock.git
+	branch = refs/heads/master
 [submodule "fastavro"]
 	path = feedstocks/fastavro
 	url = https://github.com/conda-forge/fastavro-feedstock.git
+	branch = refs/heads/master
 [submodule "otfftw"]
 	path = feedstocks/otfftw
 	url = https://github.com/conda-forge/otfftw-feedstock.git
+	branch = refs/heads/master
 [submodule "otmorris"]
 	path = feedstocks/otmorris
 	url = https://github.com/conda-forge/otmorris-feedstock.git
+	branch = refs/heads/master
 [submodule "otpmml"]
 	path = feedstocks/otpmml
 	url = https://github.com/conda-forge/otpmml-feedstock.git
+	branch = refs/heads/master
 [submodule "psiturk"]
 	path = feedstocks/psiturk
 	url = https://github.com/conda-forge/psiturk-feedstock.git
+	branch = refs/heads/master
 [submodule "py4j"]
 	path = feedstocks/py4j
 	url = https://github.com/conda-forge/py4j-feedstock.git
+	branch = refs/heads/master
 [submodule "pysmbclient"]
 	path = feedstocks/pysmbclient
 	url = https://github.com/conda-forge/pysmbclient-feedstock.git
+	branch = refs/heads/master
 [submodule "requests-futures"]
 	path = feedstocks/requests-futures
 	url = https://github.com/conda-forge/requests-futures-feedstock.git
+	branch = refs/heads/master
 [submodule "vertica-python"]
 	path = feedstocks/vertica-python
 	url = https://github.com/conda-forge/vertica-python-feedstock.git
+	branch = refs/heads/master
 [submodule "wtforms-appengine"]
 	path = feedstocks/wtforms-appengine
 	url = https://github.com/conda-forge/wtforms-appengine-feedstock.git
+	branch = refs/heads/master
 [submodule "versioneer"]
 	path = feedstocks/versioneer
 	url = https://github.com/conda-forge/versioneer-feedstock.git
+	branch = refs/heads/master
 [submodule "astroid"]
 	path = feedstocks/astroid
 	url = https://github.com/conda-forge/astroid-feedstock.git
+	branch = refs/heads/master
 [submodule "hive-thrift-py"]
 	path = feedstocks/hive-thrift-py
 	url = https://github.com/conda-forge/hive-thrift-py-feedstock.git
+	branch = refs/heads/master
 [submodule "logilab-common"]
 	path = feedstocks/logilab-common
 	url = https://github.com/conda-forge/logilab-common-feedstock.git
+	branch = refs/heads/master
 [submodule "pylint"]
 	path = feedstocks/pylint
 	url = https://github.com/conda-forge/pylint-feedstock.git
+	branch = refs/heads/master
 [submodule "eventlet"]
 	path = feedstocks/eventlet
 	url = https://github.com/conda-forge/eventlet-feedstock.git
+	branch = refs/heads/master
 [submodule "frosted"]
 	path = feedstocks/frosted
 	url = https://github.com/conda-forge/frosted-feedstock.git
+	branch = refs/heads/master
 [submodule "pyasn1"]
 	path = feedstocks/pyasn1
 	url = https://github.com/conda-forge/pyasn1-feedstock.git
+	branch = refs/heads/master
 [submodule "requirements-detector"]
 	path = feedstocks/requirements-detector
 	url = https://github.com/conda-forge/requirements-detector-feedstock.git
+	branch = refs/heads/master
 [submodule "argparse"]
 	path = feedstocks/argparse
 	url = https://github.com/conda-forge/argparse-feedstock.git
+	branch = refs/heads/master
 [submodule "flo"]
 	path = feedstocks/flo
 	url = https://github.com/conda-forge/flo-feedstock.git
+	branch = refs/heads/master
 [submodule "pylint-plugin-utils"]
 	path = feedstocks/pylint-plugin-utils
 	url = https://github.com/conda-forge/pylint-plugin-utils-feedstock.git
+	branch = refs/heads/master
 [submodule "pysocks"]
 	path = feedstocks/pysocks
 	url = https://github.com/conda-forge/pysocks-feedstock.git
+	branch = refs/heads/master
 [submodule "unidecode"]
 	path = feedstocks/unidecode
 	url = https://github.com/conda-forge/unidecode-feedstock.git
+	branch = refs/heads/master
 [submodule "argh"]
 	path = feedstocks/argh
 	url = https://github.com/conda-forge/argh-feedstock.git
+	branch = refs/heads/master
 [submodule "cerberus"]
 	path = feedstocks/cerberus
 	url = https://github.com/conda-forge/cerberus-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-httpauth"]
 	path = feedstocks/flask-httpauth
 	url = https://github.com/conda-forge/flask-httpauth-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_dashboards"]
 	path = feedstocks/jupyter_dashboards
 	url = https://github.com/conda-forge/jupyter_dashboards-feedstock.git
+	branch = refs/heads/master
 [submodule "mechanize"]
 	path = feedstocks/mechanize
 	url = https://github.com/conda-forge/mechanize-feedstock.git
+	branch = refs/heads/master
 [submodule "pathtools"]
 	path = feedstocks/pathtools
 	url = https://github.com/conda-forge/pathtools-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxjp.themecore"]
 	path = feedstocks/sphinxjp.themecore
 	url = https://github.com/conda-forge/sphinxjp.themecore-feedstock.git
+	branch = refs/heads/master
 [submodule "xmltodict"]
 	path = feedstocks/xmltodict
 	url = https://github.com/conda-forge/xmltodict-feedstock.git
+	branch = refs/heads/master
 [submodule "cryptography-vectors"]
 	path = feedstocks/cryptography-vectors
 	url = https://github.com/conda-forge/cryptography-vectors-feedstock.git
+	branch = refs/heads/master
 [submodule "exifread"]
 	path = feedstocks/exifread
 	url = https://github.com/conda-forge/exifread-feedstock.git
+	branch = refs/heads/master
 [submodule "futures"]
 	path = feedstocks/futures
 	url = https://github.com/conda-forge/futures-feedstock.git
+	branch = refs/heads/master
 [submodule "idna"]
 	path = feedstocks/idna
 	url = https://github.com/conda-forge/idna-feedstock.git
+	branch = refs/heads/master
 [submodule "inifile"]
 	path = feedstocks/inifile
 	url = https://github.com/conda-forge/inifile-feedstock.git
+	branch = refs/heads/master
 [submodule "ipython-sql"]
 	path = feedstocks/ipython-sql
 	url = https://github.com/conda-forge/ipython-sql-feedstock.git
+	branch = refs/heads/master
 [submodule "itsdangerous"]
 	path = feedstocks/itsdangerous
 	url = https://github.com/conda-forge/itsdangerous-feedstock.git
+	branch = refs/heads/master
 [submodule "openmesh"]
 	path = feedstocks/openmesh
 	url = https://github.com/conda-forge/openmesh-feedstock.git
+	branch = refs/heads/master
 [submodule "pycparser"]
 	path = feedstocks/pycparser
 	url = https://github.com/conda-forge/pycparser-feedstock.git
+	branch = refs/heads/master
 [submodule "pylint-celery"]
 	path = feedstocks/pylint-celery
 	url = https://github.com/conda-forge/pylint-celery-feedstock.git
+	branch = refs/heads/master
 [submodule "pylint-common"]
 	path = feedstocks/pylint-common
 	url = https://github.com/conda-forge/pylint-common-feedstock.git
+	branch = refs/heads/master
 [submodule "rvlib"]
 	path = feedstocks/rvlib
 	url = https://github.com/conda-forge/rvlib-feedstock.git
+	branch = refs/heads/master
 [submodule "textblob"]
 	path = feedstocks/textblob
 	url = https://github.com/conda-forge/textblob-feedstock.git
+	branch = refs/heads/master
 [submodule "werkzeug"]
 	path = feedstocks/werkzeug
 	url = https://github.com/conda-forge/werkzeug-feedstock.git
+	branch = refs/heads/master
 [submodule "twine"]
 	path = feedstocks/twine
 	url = https://github.com/conda-forge/twine-feedstock.git
+	branch = refs/heads/master
 [submodule "ebooklib"]
 	path = feedstocks/ebooklib
 	url = https://github.com/conda-forge/ebooklib-feedstock.git
+	branch = refs/heads/master
 [submodule "traceback2"]
 	path = feedstocks/traceback2
 	url = https://github.com/conda-forge/traceback2-feedstock.git
+	branch = refs/heads/master
 [submodule "cyclus"]
 	path = feedstocks/cyclus
 	url = https://github.com/conda-forge/cyclus-feedstock.git
+	branch = refs/heads/master
 [submodule "fatiando"]
 	path = feedstocks/fatiando
 	url = https://github.com/conda-forge/fatiando-feedstock.git
+	branch = refs/heads/master
 [submodule "flask"]
 	path = feedstocks/flask
 	url = https://github.com/conda-forge/flask-feedstock.git
+	branch = refs/heads/master
 [submodule "nltk"]
 	path = feedstocks/nltk
 	url = https://github.com/conda-forge/nltk-feedstock.git
+	branch = refs/heads/master
 [submodule "prospector"]
 	path = feedstocks/prospector
 	url = https://github.com/conda-forge/prospector-feedstock.git
+	branch = refs/heads/master
 [submodule "pylint-django"]
 	path = feedstocks/pylint-django
 	url = https://github.com/conda-forge/pylint-django-feedstock.git
+	branch = refs/heads/master
 [submodule "pylint-flask"]
 	path = feedstocks/pylint-flask
 	url = https://github.com/conda-forge/pylint-flask-feedstock.git
+	branch = refs/heads/master
 [submodule "django-nose"]
 	path = feedstocks/django-nose
 	url = https://github.com/conda-forge/django-nose-feedstock.git
+	branch = refs/heads/master
 [submodule "phconvert"]
 	path = feedstocks/phconvert
 	url = https://github.com/conda-forge/phconvert-feedstock.git
+	branch = refs/heads/master
 [submodule "pretend"]
 	path = feedstocks/pretend
 	url = https://github.com/conda-forge/pretend-feedstock.git
+	branch = refs/heads/master
 [submodule "pybroom"]
 	path = feedstocks/pybroom
 	url = https://github.com/conda-forge/pybroom-feedstock.git
+	branch = refs/heads/master
 [submodule "traittypes"]
 	path = feedstocks/traittypes
 	url = https://github.com/conda-forge/traittypes-feedstock.git
+	branch = refs/heads/master
 [submodule "yarg"]
 	path = feedstocks/yarg
 	url = https://github.com/conda-forge/yarg-feedstock.git
+	branch = refs/heads/master
 [submodule "dbus"]
 	path = feedstocks/dbus
 	url = https://github.com/conda-forge/dbus-feedstock.git
+	branch = refs/heads/master
 [submodule "gstreamer"]
 	path = feedstocks/gstreamer
 	url = https://github.com/conda-forge/gstreamer-feedstock.git
+	branch = refs/heads/master
 [submodule "instaseis"]
 	path = feedstocks/instaseis
 	url = https://github.com/conda-forge/instaseis-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-profiling"]
 	path = feedstocks/pandas-profiling
 	url = https://github.com/conda-forge/pandas-profiling-feedstock.git
+	branch = refs/heads/master
 [submodule "vobject"]
 	path = feedstocks/vobject
 	url = https://github.com/conda-forge/vobject-feedstock.git
+	branch = refs/heads/master
 [submodule "xcb-proto"]
 	path = feedstocks/xcb-proto
 	url = https://github.com/conda-forge/xcb-proto-feedstock.git
+	branch = refs/heads/master
 [submodule "cement"]
 	path = feedstocks/cement
 	url = https://github.com/conda-forge/cement-feedstock.git
+	branch = refs/heads/master
 [submodule "configargparse"]
 	path = feedstocks/configargparse
 	url = https://github.com/conda-forge/configargparse-feedstock.git
+	branch = refs/heads/master
 [submodule "cycamore"]
 	path = feedstocks/cycamore
 	url = https://github.com/conda-forge/cycamore-feedstock.git
+	branch = refs/heads/master
 [submodule "fabric"]
 	path = feedstocks/fabric
 	url = https://github.com/conda-forge/fabric-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-mail"]
 	path = feedstocks/flask-mail
 	url = https://github.com/conda-forge/flask-mail-feedstock.git
+	branch = refs/heads/master
 [submodule "mongoengine"]
 	path = feedstocks/mongoengine
 	url = https://github.com/conda-forge/mongoengine-feedstock.git
+	branch = refs/heads/master
 [submodule "pthread-stubs"]
 	path = feedstocks/pthread-stubs
 	url = https://github.com/conda-forge/pthread-stubs-feedstock.git
+	branch = refs/heads/master
 [submodule "requests-cache"]
 	path = feedstocks/requests-cache
 	url = https://github.com/conda-forge/requests-cache-feedstock.git
+	branch = refs/heads/master
 [submodule "tldextract"]
 	path = feedstocks/tldextract
 	url = https://github.com/conda-forge/tldextract-feedstock.git
+	branch = refs/heads/master
 [submodule "toro"]
 	path = feedstocks/toro
 	url = https://github.com/conda-forge/toro-feedstock.git
+	branch = refs/heads/master
 [submodule "watchdog"]
 	path = feedstocks/watchdog
 	url = https://github.com/conda-forge/watchdog-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-basicauth"]
 	path = feedstocks/flask-basicauth
 	url = https://github.com/conda-forge/flask-basicauth-feedstock.git
+	branch = refs/heads/master
 [submodule "libxcb"]
 	path = feedstocks/libxcb
 	url = https://github.com/conda-forge/libxcb-feedstock.git
+	branch = refs/heads/master
 [submodule "ndg-httpsclient"]
 	path = feedstocks/ndg-httpsclient
 	url = https://github.com/conda-forge/ndg-httpsclient-feedstock.git
+	branch = refs/heads/master
 [submodule "pdfminer.six"]
 	path = feedstocks/pdfminer.six
 	url = https://github.com/conda-forge/pdfminer.six-feedstock.git
+	branch = refs/heads/master
 [submodule "wtf-peewee"]
 	path = feedstocks/wtf-peewee
 	url = https://github.com/conda-forge/wtf-peewee-feedstock.git
+	branch = refs/heads/master
 [submodule "cov-core"]
 	path = feedstocks/cov-core
 	url = https://github.com/conda-forge/cov-core-feedstock.git
+	branch = refs/heads/master
 [submodule "libxslt"]
 	path = feedstocks/libxslt
 	url = https://github.com/conda-forge/libxslt-feedstock.git
+	branch = refs/heads/master
 [submodule "lxml"]
 	path = feedstocks/lxml
 	url = https://github.com/conda-forge/lxml-feedstock.git
+	branch = refs/heads/master
 [submodule "backports.ssl"]
 	path = feedstocks/backports.ssl
 	url = https://github.com/conda-forge/backports.ssl-feedstock.git
+	branch = refs/heads/master
 [submodule "cloudant"]
 	path = feedstocks/cloudant
 	url = https://github.com/conda-forge/cloudant-feedstock.git
+	branch = refs/heads/master
 [submodule "datreant"]
 	path = feedstocks/datreant
 	url = https://github.com/conda-forge/datreant-feedstock.git
+	branch = refs/heads/master
 [submodule "datreant.core"]
 	path = feedstocks/datreant.core
 	url = https://github.com/conda-forge/datreant.core-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-principal"]
 	path = feedstocks/flask-principal
 	url = https://github.com/conda-forge/flask-principal-feedstock.git
+	branch = refs/heads/master
 [submodule "grequests"]
 	path = feedstocks/grequests
 	url = https://github.com/conda-forge/grequests-feedstock.git
+	branch = refs/heads/master
 [submodule "pyasn1-modules"]
 	path = feedstocks/pyasn1-modules
 	url = https://github.com/conda-forge/pyasn1-modules-feedstock.git
+	branch = refs/heads/master
 [submodule "sentinels"]
 	path = feedstocks/sentinels
 	url = https://github.com/conda-forge/sentinels-feedstock.git
+	branch = refs/heads/master
 [submodule "wsgiref"]
 	path = feedstocks/wsgiref
 	url = https://github.com/conda-forge/wsgiref-feedstock.git
+	branch = refs/heads/master
 [submodule "doublemetaphone"]
 	path = feedstocks/doublemetaphone
 	url = https://github.com/conda-forge/doublemetaphone-feedstock.git
+	branch = refs/heads/master
 [submodule "testtools"]
 	path = feedstocks/testtools
 	url = https://github.com/conda-forge/testtools-feedstock.git
+	branch = refs/heads/master
 [submodule "blosc"]
 	path = feedstocks/blosc
 	url = https://github.com/conda-forge/blosc-feedstock.git
+	branch = refs/heads/master
 [submodule "bloscpack"]
 	path = feedstocks/bloscpack
 	url = https://github.com/conda-forge/bloscpack-feedstock.git
+	branch = refs/heads/master
 [submodule "mdtraj"]
 	path = feedstocks/mdtraj
 	url = https://github.com/conda-forge/mdtraj-feedstock.git
+	branch = refs/heads/master
 [submodule "python-blosc"]
 	path = feedstocks/python-blosc
 	url = https://github.com/conda-forge/python-blosc-feedstock.git
+	branch = refs/heads/master
 [submodule "islpy"]
 	path = feedstocks/islpy
 	url = https://github.com/conda-forge/islpy-feedstock.git
+	branch = refs/heads/master
 [submodule "libhwloc"]
 	path = feedstocks/libhwloc
 	url = https://github.com/conda-forge/libhwloc-feedstock.git
+	branch = refs/heads/master
 [submodule "pyagrum"]
 	path = feedstocks/pyagrum
 	url = https://github.com/conda-forge/pyagrum-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-cookies"]
 	path = feedstocks/pytest-cookies
 	url = https://github.com/conda-forge/pytest-cookies-feedstock.git
+	branch = refs/heads/master
 [submodule "imapclient"]
 	path = feedstocks/imapclient
 	url = https://github.com/conda-forge/imapclient-feedstock.git
+	branch = refs/heads/master
 [submodule "mpi4py"]
 	path = feedstocks/mpi4py
 	url = https://github.com/conda-forge/mpi4py-feedstock.git
+	branch = refs/heads/master
 [submodule "paramiko"]
 	path = feedstocks/paramiko
 	url = https://github.com/conda-forge/paramiko-feedstock.git
+	branch = refs/heads/master
 [submodule "fabric3"]
 	path = feedstocks/fabric3
 	url = https://github.com/conda-forge/fabric3-feedstock.git
+	branch = refs/heads/master
 [submodule "fixtures"]
 	path = feedstocks/fixtures
 	url = https://github.com/conda-forge/fixtures-feedstock.git
+	branch = refs/heads/master
 [submodule "hachoir-regex"]
 	path = feedstocks/hachoir-regex
 	url = https://github.com/conda-forge/hachoir-regex-feedstock.git
+	branch = refs/heads/master
 [submodule "hachoir-urwid"]
 	path = feedstocks/hachoir-urwid
 	url = https://github.com/conda-forge/hachoir-urwid-feedstock.git
+	branch = refs/heads/master
 [submodule "iris-grib"]
 	path = feedstocks/iris-grib
 	url = https://github.com/conda-forge/iris-grib-feedstock.git
+	branch = refs/heads/master
 [submodule "iris-sample-data"]
 	path = feedstocks/iris-sample-data
 	url = https://github.com/conda-forge/iris-sample-data-feedstock.git
+	branch = refs/heads/master
 [submodule "python-engineio"]
 	path = feedstocks/python-engineio
 	url = https://github.com/conda-forge/python-engineio-feedstock.git
+	branch = refs/heads/master
 [submodule "cube_browser"]
 	path = feedstocks/cube_browser
 	url = https://github.com/conda-forge/cube_browser-feedstock.git
+	branch = refs/heads/master
 [submodule "hachoir-wx"]
 	path = feedstocks/hachoir-wx
 	url = https://github.com/conda-forge/hachoir-wx-feedstock.git
+	branch = refs/heads/master
 [submodule "mrjob"]
 	path = feedstocks/mrjob
 	url = https://github.com/conda-forge/mrjob-feedstock.git
+	branch = refs/heads/master
 [submodule "pyxley"]
 	path = feedstocks/pyxley
 	url = https://github.com/conda-forge/pyxley-feedstock.git
+	branch = refs/heads/master
 [submodule "bcdoc"]
 	path = feedstocks/bcdoc
 	url = https://github.com/conda-forge/bcdoc-feedstock.git
+	branch = refs/heads/master
 [submodule "bottle"]
 	path = feedstocks/bottle
 	url = https://github.com/conda-forge/bottle-feedstock.git
+	branch = refs/heads/master
 [submodule "fretbursts"]
 	path = feedstocks/fretbursts
 	url = https://github.com/conda-forge/fretbursts-feedstock.git
+	branch = refs/heads/master
 [submodule "ipython-autotime"]
 	path = feedstocks/ipython-autotime
 	url = https://github.com/conda-forge/ipython-autotime-feedstock.git
+	branch = refs/heads/master
 [submodule "metis"]
 	path = feedstocks/metis
 	url = https://github.com/conda-forge/metis-feedstock.git
+	branch = refs/heads/master
 [submodule "openmpi"]
 	path = feedstocks/openmpi
 	url = https://github.com/conda-forge/openmpi-feedstock.git
+	branch = refs/heads/master
 [submodule "pathlib"]
 	path = feedstocks/pathlib
 	url = https://github.com/conda-forge/pathlib-feedstock.git
+	branch = refs/heads/master
 [submodule "pipreqs"]
 	path = feedstocks/pipreqs
 	url = https://github.com/conda-forge/pipreqs-feedstock.git
+	branch = refs/heads/master
 [submodule "pyinstrument"]
 	path = feedstocks/pyinstrument
 	url = https://github.com/conda-forge/pyinstrument-feedstock.git
+	branch = refs/heads/master
 [submodule "python-annoy"]
 	path = feedstocks/python-annoy
 	url = https://github.com/conda-forge/python-annoy-feedstock.git
+	branch = refs/heads/master
 [submodule "python-termstyle"]
 	path = feedstocks/python-termstyle
 	url = https://github.com/conda-forge/python-termstyle-feedstock.git
+	branch = refs/heads/master
 [submodule "wakatime"]
 	path = feedstocks/wakatime
 	url = https://github.com/conda-forge/wakatime-feedstock.git
+	branch = refs/heads/master
 [submodule "heapdict"]
 	path = feedstocks/heapdict
 	url = https://github.com/conda-forge/heapdict-feedstock.git
+	branch = refs/heads/master
 [submodule "creoleparser"]
 	path = feedstocks/creoleparser
 	url = https://github.com/conda-forge/creoleparser-feedstock.git
+	branch = refs/heads/master
 [submodule "falcon"]
 	path = feedstocks/falcon
 	url = https://github.com/conda-forge/falcon-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-restful"]
 	path = feedstocks/flask-restful
 	url = https://github.com/conda-forge/flask-restful-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-seasurf"]
 	path = feedstocks/flask-seasurf
 	url = https://github.com/conda-forge/flask-seasurf-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-testing"]
 	path = feedstocks/flask-testing
 	url = https://github.com/conda-forge/flask-testing-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-uploads"]
 	path = feedstocks/flask-uploads
 	url = https://github.com/conda-forge/flask-uploads-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-user"]
 	path = feedstocks/flask-user
 	url = https://github.com/conda-forge/flask-user-feedstock.git
+	branch = refs/heads/master
 [submodule "hachoir-subfile"]
 	path = feedstocks/hachoir-subfile
 	url = https://github.com/conda-forge/hachoir-subfile-feedstock.git
+	branch = refs/heads/master
 [submodule "mimerender"]
 	path = feedstocks/mimerender
 	url = https://github.com/conda-forge/mimerender-feedstock.git
+	branch = refs/heads/master
 [submodule "pybufr-ecmwf"]
 	path = feedstocks/pybufr-ecmwf
 	url = https://github.com/conda-forge/pybufr-ecmwf-feedstock.git
+	branch = refs/heads/master
 [submodule "pygmo"]
 	path = feedstocks/pygmo
 	url = https://github.com/conda-forge/pygmo-feedstock.git
+	branch = refs/heads/master
 [submodule "slugify"]
 	path = feedstocks/slugify
 	url = https://github.com/conda-forge/slugify-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx-issues"]
 	path = feedstocks/sphinx-issues
 	url = https://github.com/conda-forge/sphinx-issues-feedstock.git
+	branch = refs/heads/master
 [submodule "uncommitted"]
 	path = feedstocks/uncommitted
 	url = https://github.com/conda-forge/uncommitted-feedstock.git
+	branch = refs/heads/master
 [submodule "update_checker"]
 	path = feedstocks/update_checker
 	url = https://github.com/conda-forge/update_checker-feedstock.git
+	branch = refs/heads/master
 [submodule "zict"]
 	path = feedstocks/zict
 	url = https://github.com/conda-forge/zict-feedstock.git
+	branch = refs/heads/master
 [submodule "zodburi"]
 	path = feedstocks/zodburi
 	url = https://github.com/conda-forge/zodburi-feedstock.git
+	branch = refs/heads/master
 [submodule "datreant.data"]
 	path = feedstocks/datreant.data
 	url = https://github.com/conda-forge/datreant.data-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-genshi"]
 	path = feedstocks/flask-genshi
 	url = https://github.com/conda-forge/flask-genshi-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-xml-rpc"]
 	path = feedstocks/flask-xml-rpc
 	url = https://github.com/conda-forge/flask-xml-rpc-feedstock.git
+	branch = refs/heads/master
 [submodule "frozen-flask"]
 	path = feedstocks/frozen-flask
 	url = https://github.com/conda-forge/frozen-flask-feedstock.git
+	branch = refs/heads/master
 [submodule "gst-plugins-base"]
 	path = feedstocks/gst-plugins-base
 	url = https://github.com/conda-forge/gst-plugins-base-feedstock.git
+	branch = refs/heads/master
 [submodule "lockfile"]
 	path = feedstocks/lockfile
 	url = https://github.com/conda-forge/lockfile-feedstock.git
+	branch = refs/heads/master
 [submodule "marshmallow"]
 	path = feedstocks/marshmallow
 	url = https://github.com/conda-forge/marshmallow-feedstock.git
+	branch = refs/heads/master
 [submodule "python-couchdb"]
 	path = feedstocks/python-couchdb
 	url = https://github.com/conda-forge/python-couchdb-feedstock.git
+	branch = refs/heads/master
 [submodule "python-highcharts"]
 	path = feedstocks/python-highcharts
 	url = https://github.com/conda-forge/python-highcharts-feedstock.git
+	branch = refs/heads/master
 [submodule "python-socketio"]
 	path = feedstocks/python-socketio
 	url = https://github.com/conda-forge/python-socketio-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx-pypi-upload"]
 	path = feedstocks/sphinx-pypi-upload
 	url = https://github.com/conda-forge/sphinx-pypi-upload-feedstock.git
+	branch = refs/heads/master
 [submodule "sseclient"]
 	path = feedstocks/sseclient
 	url = https://github.com/conda-forge/sseclient-feedstock.git
+	branch = refs/heads/master
 [submodule "markdown2"]
 	path = feedstocks/markdown2
 	url = https://github.com/conda-forge/markdown2-feedstock.git
+	branch = refs/heads/master
 [submodule "oslo.i18n"]
 	path = feedstocks/oslo.i18n
 	url = https://github.com/conda-forge/oslo.i18n-feedstock.git
+	branch = refs/heads/master
 [submodule "pyqt"]
 	path = feedstocks/pyqt
 	url = https://github.com/conda-forge/pyqt-feedstock.git
+	branch = refs/heads/master
 [submodule "sh"]
 	path = feedstocks/sh
 	url = https://github.com/conda-forge/sh-feedstock.git
+	branch = refs/heads/master
 [submodule "dlib"]
 	path = feedstocks/dlib
 	url = https://github.com/conda-forge/dlib-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-quotes"]
 	path = feedstocks/flake8-quotes
 	url = https://github.com/conda-forge/flake8-quotes-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-moment"]
 	path = feedstocks/flask-moment
 	url = https://github.com/conda-forge/flask-moment-feedstock.git
+	branch = refs/heads/master
 [submodule "gtest"]
 	path = feedstocks/gtest
 	url = https://github.com/conda-forge/gtest-feedstock.git
+	branch = refs/heads/master
 [submodule "multipledispatch"]
 	path = feedstocks/multipledispatch
 	url = https://github.com/conda-forge/multipledispatch-feedstock.git
+	branch = refs/heads/master
 [submodule "qca"]
 	path = feedstocks/qca
 	url = https://github.com/conda-forge/qca-feedstock.git
+	branch = refs/heads/master
 [submodule "qjson"]
 	path = feedstocks/qjson
 	url = https://github.com/conda-forge/qjson-feedstock.git
+	branch = refs/heads/master
 [submodule "factory_boy"]
 	path = feedstocks/factory_boy
 	url = https://github.com/conda-forge/factory_boy-feedstock.git
+	branch = refs/heads/master
 [submodule "pygeoip"]
 	path = feedstocks/pygeoip
 	url = https://github.com/conda-forge/pygeoip-feedstock.git
+	branch = refs/heads/master
 [submodule "qscintilla2"]
 	path = feedstocks/qscintilla2
 	url = https://github.com/conda-forge/qscintilla2-feedstock.git
+	branch = refs/heads/master
 [submodule "webassets"]
 	path = feedstocks/webassets
 	url = https://github.com/conda-forge/webassets-feedstock.git
+	branch = refs/heads/master
 [submodule "bidict"]
 	path = feedstocks/bidict
 	url = https://github.com/conda-forge/bidict-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-cors"]
 	path = feedstocks/flask-cors
 	url = https://github.com/conda-forge/flask-cors-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-couchdb"]
 	path = feedstocks/flask-couchdb
 	url = https://github.com/conda-forge/flask-couchdb-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-restless"]
 	path = feedstocks/flask-restless
 	url = https://github.com/conda-forge/flask-restless-feedstock.git
+	branch = refs/heads/master
 [submodule "jellyfish"]
 	path = feedstocks/jellyfish
 	url = https://github.com/conda-forge/jellyfish-feedstock.git
+	branch = refs/heads/master
 [submodule "parsedatetime"]
 	path = feedstocks/parsedatetime
 	url = https://github.com/conda-forge/parsedatetime-feedstock.git
+	branch = refs/heads/master
 [submodule "genson"]
 	path = feedstocks/genson
 	url = https://github.com/conda-forge/genson-feedstock.git
+	branch = refs/heads/master
 [submodule "python-openid"]
 	path = feedstocks/python-openid
 	url = https://github.com/conda-forge/python-openid-feedstock.git
+	branch = refs/heads/master
 [submodule "sqlalchemy-utils"]
 	path = feedstocks/sqlalchemy-utils
 	url = https://github.com/conda-forge/sqlalchemy-utils-feedstock.git
+	branch = refs/heads/master
 [submodule "visitor"]
 	path = feedstocks/visitor
 	url = https://github.com/conda-forge/visitor-feedstock.git
+	branch = refs/heads/master
 [submodule "zodbpickle"]
 	path = feedstocks/zodbpickle
 	url = https://github.com/conda-forge/zodbpickle-feedstock.git
+	branch = refs/heads/master
 [submodule "begins"]
 	path = feedstocks/begins
 	url = https://github.com/conda-forge/begins-feedstock.git
+	branch = refs/heads/master
 [submodule "dominate"]
 	path = feedstocks/dominate
 	url = https://github.com/conda-forge/dominate-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-creole"]
 	path = feedstocks/flask-creole
 	url = https://github.com/conda-forge/flask-creole-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-debugtoolbar"]
 	path = feedstocks/flask-debugtoolbar
 	url = https://github.com/conda-forge/flask-debugtoolbar-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-socketio"]
 	path = feedstocks/flask-socketio
 	url = https://github.com/conda-forge/flask-socketio-feedstock.git
+	branch = refs/heads/master
 [submodule "htop"]
 	path = feedstocks/htop
 	url = https://github.com/conda-forge/htop-feedstock.git
+	branch = refs/heads/master
 [submodule "hyperion"]
 	path = feedstocks/hyperion
 	url = https://github.com/conda-forge/hyperion-feedstock.git
+	branch = refs/heads/master
 [submodule "hyperion-fortran"]
 	path = feedstocks/hyperion-fortran
 	url = https://github.com/conda-forge/hyperion-fortran-feedstock.git
+	branch = refs/heads/master
 [submodule "inspyred"]
 	path = feedstocks/inspyred
 	url = https://github.com/conda-forge/inspyred-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_cms"]
 	path = feedstocks/jupyter_cms
 	url = https://github.com/conda-forge/jupyter_cms-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_kernel_gateway"]
 	path = feedstocks/jupyter_kernel_gateway
 	url = https://github.com/conda-forge/jupyter_kernel_gateway-feedstock.git
+	branch = refs/heads/master
 [submodule "numcodecs"]
 	path = feedstocks/numcodecs
 	url = https://github.com/conda-forge/numcodecs-feedstock.git
+	branch = refs/heads/master
 [submodule "oslo.config"]
 	path = feedstocks/oslo.config
 	url = https://github.com/conda-forge/oslo.config-feedstock.git
+	branch = refs/heads/master
 [submodule "pygraphml"]
 	path = feedstocks/pygraphml
 	url = https://github.com/conda-forge/pygraphml-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-cpp"]
 	path = feedstocks/pytest-cpp
 	url = https://github.com/conda-forge/pytest-cpp-feedstock.git
+	branch = refs/heads/master
 [submodule "python-slugify"]
 	path = feedstocks/python-slugify
 	url = https://github.com/conda-forge/python-slugify-feedstock.git
+	branch = refs/heads/master
 [submodule "qgis"]
 	path = feedstocks/qgis
 	url = https://github.com/conda-forge/qgis-feedstock.git
+	branch = refs/heads/master
 [submodule "splits"]
 	path = feedstocks/splits
 	url = https://github.com/conda-forge/splits-feedstock.git
+	branch = refs/heads/master
 [submodule "tpot"]
 	path = feedstocks/tpot
 	url = https://github.com/conda-forge/tpot-feedstock.git
+	branch = refs/heads/master
 [submodule "viridis"]
 	path = feedstocks/viridis
 	url = https://github.com/conda-forge/viridis-feedstock.git
+	branch = refs/heads/master
 [submodule "visvis"]
 	path = feedstocks/visvis
 	url = https://github.com/conda-forge/visvis-feedstock.git
+	branch = refs/heads/master
 [submodule "defusedxml"]
 	path = feedstocks/defusedxml
 	url = https://github.com/conda-forge/defusedxml-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-flatpages"]
 	path = feedstocks/flask-flatpages
 	url = https://github.com/conda-forge/flask-flatpages-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-script"]
 	path = feedstocks/flask-script
 	url = https://github.com/conda-forge/flask-script-feedstock.git
+	branch = refs/heads/master
 [submodule "msg-extractor"]
 	path = feedstocks/msg-extractor
 	url = https://github.com/conda-forge/msg-extractor-feedstock.git
+	branch = refs/heads/master
 [submodule "nbexamples"]
 	path = feedstocks/nbexamples
 	url = https://github.com/conda-forge/nbexamples-feedstock.git
+	branch = refs/heads/master
 [submodule "oslo.utils"]
 	path = feedstocks/oslo.utils
 	url = https://github.com/conda-forge/oslo.utils-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-highcharts"]
 	path = feedstocks/pandas-highcharts
 	url = https://github.com/conda-forge/pandas-highcharts-feedstock.git
+	branch = refs/heads/master
 [submodule "seqan-library"]
 	path = feedstocks/seqan-library
 	url = https://github.com/conda-forge/seqan-library-feedstock.git
+	branch = refs/heads/master
 [submodule "us"]
 	path = feedstocks/us
 	url = https://github.com/conda-forge/us-feedstock.git
+	branch = refs/heads/master
 [submodule "versiontools"]
 	path = feedstocks/versiontools
 	url = https://github.com/conda-forge/versiontools-feedstock.git
+	branch = refs/heads/master
 [submodule "msmtools"]
 	path = feedstocks/msmtools
 	url = https://github.com/conda-forge/msmtools-feedstock.git
+	branch = refs/heads/master
 [submodule "sundials"]
 	path = feedstocks/sundials
 	url = https://github.com/conda-forge/sundials-feedstock.git
+	branch = refs/heads/master
 [submodule "textract"]
 	path = feedstocks/textract
 	url = https://github.com/conda-forge/textract-feedstock.git
+	branch = refs/heads/master
 [submodule "emacs"]
 	path = feedstocks/emacs
 	url = https://github.com/conda-forge/emacs-feedstock.git
+	branch = refs/heads/master
 [submodule "pkgconfig"]
 	path = feedstocks/pkgconfig
 	url = https://github.com/conda-forge/pkgconfig-feedstock.git
+	branch = refs/heads/master
 [submodule "python3-openid"]
 	path = feedstocks/python3-openid
 	url = https://github.com/conda-forge/python3-openid-feedstock.git
+	branch = refs/heads/master
 [submodule "gala"]
 	path = feedstocks/gala
 	url = https://github.com/conda-forge/gala-feedstock.git
+	branch = refs/heads/master
 [submodule "cheat"]
 	path = feedstocks/cheat
 	url = https://github.com/conda-forge/cheat-feedstock.git
+	branch = refs/heads/master
 [submodule "openpiv"]
 	path = feedstocks/openpiv
 	url = https://github.com/conda-forge/openpiv-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-summary"]
 	path = feedstocks/pandas-summary
 	url = https://github.com/conda-forge/pandas-summary-feedstock.git
+	branch = refs/heads/master
 [submodule "pygrametl"]
 	path = feedstocks/pygrametl
 	url = https://github.com/conda-forge/pygrametl-feedstock.git
+	branch = refs/heads/master
 [submodule "arpack"]
 	path = feedstocks/arpack
 	url = https://github.com/conda-forge/arpack-feedstock.git
+	branch = refs/heads/master
 [submodule "arpackpp"]
 	path = feedstocks/arpackpp
 	url = https://github.com/conda-forge/arpackpp-feedstock.git
+	branch = refs/heads/master
 [submodule "moab"]
 	path = feedstocks/moab
 	url = https://github.com/conda-forge/moab-feedstock.git
+	branch = refs/heads/master
 [submodule "repeated_test"]
 	path = feedstocks/repeated_test
 	url = https://github.com/conda-forge/repeated_test-feedstock.git
+	branch = refs/heads/master
 [submodule "unzip"]
 	path = feedstocks/unzip
 	url = https://github.com/conda-forge/unzip-feedstock.git
+	branch = refs/heads/master
 [submodule "zip"]
 	path = feedstocks/zip
 	url = https://github.com/conda-forge/zip-feedstock.git
+	branch = refs/heads/master
 [submodule "contextily"]
 	path = feedstocks/contextily
 	url = https://github.com/conda-forge/contextily-feedstock.git
+	branch = refs/heads/master
 [submodule "mercantile"]
 	path = feedstocks/mercantile
 	url = https://github.com/conda-forge/mercantile-feedstock.git
+	branch = refs/heads/master
 [submodule "sshtunnel"]
 	path = feedstocks/sshtunnel
 	url = https://github.com/conda-forge/sshtunnel-feedstock.git
+	branch = refs/heads/master
 [submodule "autowrap"]
 	path = feedstocks/autowrap
 	url = https://github.com/conda-forge/autowrap-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-wrappers"]
 	path = feedstocks/conda-wrappers
 	url = https://github.com/conda-forge/conda-wrappers-feedstock.git
+	branch = refs/heads/master
 [submodule "petl"]
 	path = feedstocks/petl
 	url = https://github.com/conda-forge/petl-feedstock.git
+	branch = refs/heads/master
 [submodule "progress_reporter"]
 	path = feedstocks/progress_reporter
 	url = https://github.com/conda-forge/progress_reporter-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-cache"]
 	path = feedstocks/pytest-cache
 	url = https://github.com/conda-forge/pytest-cache-feedstock.git
+	branch = refs/heads/master
 [submodule "refnx"]
 	path = feedstocks/refnx
 	url = https://github.com/conda-forge/refnx-feedstock.git
+	branch = refs/heads/master
 [submodule "retrying"]
 	path = feedstocks/retrying
 	url = https://github.com/conda-forge/retrying-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-allel"]
 	path = feedstocks/scikit-allel
 	url = https://github.com/conda-forge/scikit-allel-feedstock.git
+	branch = refs/heads/master
 [submodule "tokyocabinet"]
 	path = feedstocks/tokyocabinet
 	url = https://github.com/conda-forge/tokyocabinet-feedstock.git
+	branch = refs/heads/master
 [submodule "zc.lockfile"]
 	path = feedstocks/zc.lockfile
 	url = https://github.com/conda-forge/zc.lockfile-feedstock.git
+	branch = refs/heads/master
 [submodule "periodictable"]
 	path = feedstocks/periodictable
 	url = https://github.com/conda-forge/periodictable-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-pep8"]
 	path = feedstocks/pytest-pep8
 	url = https://github.com/conda-forge/pytest-pep8-feedstock.git
+	branch = refs/heads/master
 [submodule "asteval"]
 	path = feedstocks/asteval
 	url = https://github.com/conda-forge/asteval-feedstock.git
+	branch = refs/heads/master
 [submodule "embree"]
 	path = feedstocks/embree
 	url = https://github.com/conda-forge/embree-feedstock.git
+	branch = refs/heads/master
 [submodule "pprofile"]
 	path = feedstocks/pprofile
 	url = https://github.com/conda-forge/pprofile-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-flakes"]
 	path = feedstocks/pytest-flakes
 	url = https://github.com/conda-forge/pytest-flakes-feedstock.git
+	branch = refs/heads/master
 [submodule "trackpy"]
 	path = feedstocks/trackpy
 	url = https://github.com/conda-forge/trackpy-feedstock.git
+	branch = refs/heads/master
 [submodule "click-help-colors"]
 	path = feedstocks/click-help-colors
 	url = https://github.com/conda-forge/click-help-colors-feedstock.git
+	branch = refs/heads/master
 [submodule "kenjutsu"]
 	path = feedstocks/kenjutsu
 	url = https://github.com/conda-forge/kenjutsu-feedstock.git
+	branch = refs/heads/master
 [submodule "metawrap"]
 	path = feedstocks/metawrap
 	url = https://github.com/conda-forge/metawrap-feedstock.git
+	branch = refs/heads/master
 [submodule "px4tools"]
 	path = feedstocks/px4tools
 	url = https://github.com/conda-forge/px4tools-feedstock.git
+	branch = refs/heads/master
 [submodule "census"]
 	path = feedstocks/census
 	url = https://github.com/conda-forge/census-feedstock.git
+	branch = refs/heads/master
 [submodule "openmc"]
 	path = feedstocks/openmc
 	url = https://github.com/conda-forge/openmc-feedstock.git
+	branch = refs/heads/master
 [submodule "pyelastix"]
 	path = feedstocks/pyelastix
 	url = https://github.com/conda-forge/pyelastix-feedstock.git
+	branch = refs/heads/master
 [submodule "pyembree"]
 	path = feedstocks/pyembree
 	url = https://github.com/conda-forge/pyembree-feedstock.git
+	branch = refs/heads/master
 [submodule "pymc3"]
 	path = feedstocks/pymc3
 	url = https://github.com/conda-forge/pymc3-feedstock.git
+	branch = refs/heads/master
 [submodule "pyne"]
 	path = feedstocks/pyne
 	url = https://github.com/conda-forge/pyne-feedstock.git
+	branch = refs/heads/master
 [submodule "pyside"]
 	path = feedstocks/pyside
 	url = https://github.com/conda-forge/pyside-feedstock.git
+	branch = refs/heads/master
 [submodule "validictory"]
 	path = feedstocks/validictory
 	url = https://github.com/conda-forge/validictory-feedstock.git
+	branch = refs/heads/master
 [submodule "commonmark"]
 	path = feedstocks/commonmark
 	url = https://github.com/conda-forge/commonmark-feedstock.git
+	branch = refs/heads/master
 [submodule "jpype1"]
 	path = feedstocks/jpype1
 	url = https://github.com/conda-forge/jpype1-feedstock.git
+	branch = refs/heads/master
 [submodule "ccache"]
 	path = feedstocks/ccache
 	url = https://github.com/conda-forge/ccache-feedstock.git
+	branch = refs/heads/master
 [submodule "av"]
 	path = feedstocks/av
 	url = https://github.com/conda-forge/av-feedstock.git
+	branch = refs/heads/master
 [submodule "clcache"]
 	path = feedstocks/clcache
 	url = https://github.com/conda-forge/clcache-feedstock.git
+	branch = refs/heads/master
 [submodule "fermipy"]
 	path = feedstocks/fermipy
 	url = https://github.com/conda-forge/fermipy-feedstock.git
+	branch = refs/heads/master
 [submodule "llvmdev"]
 	path = feedstocks/llvmdev
 	url = https://github.com/conda-forge/llvmdev-feedstock.git
+	branch = refs/heads/master
 [submodule "warc"]
 	path = feedstocks/warc
 	url = https://github.com/conda-forge/warc-feedstock.git
+	branch = refs/heads/master
 [submodule "warctools"]
 	path = feedstocks/warctools
 	url = https://github.com/conda-forge/warctools-feedstock.git
+	branch = refs/heads/master
 [submodule "arrow-cpp"]
 	path = feedstocks/arrow-cpp
 	url = https://github.com/conda-forge/arrow-cpp-feedstock.git
+	branch = refs/heads/master
 [submodule "breathe"]
 	path = feedstocks/breathe
 	url = https://github.com/conda-forge/breathe-feedstock.git
+	branch = refs/heads/master
 [submodule "cachetools"]
 	path = feedstocks/cachetools
 	url = https://github.com/conda-forge/cachetools-feedstock.git
+	branch = refs/heads/master
 [submodule "gdb"]
 	path = feedstocks/gdb
 	url = https://github.com/conda-forge/gdb-feedstock.git
+	branch = refs/heads/master
 [submodule "genpy"]
 	path = feedstocks/genpy
 	url = https://github.com/conda-forge/genpy-feedstock.git
+	branch = refs/heads/master
 [submodule "hpc05"]
 	path = feedstocks/hpc05
 	url = https://github.com/conda-forge/hpc05-feedstock.git
+	branch = refs/heads/master
 [submodule "kapteyn"]
 	path = feedstocks/kapteyn
 	url = https://github.com/conda-forge/kapteyn-feedstock.git
+	branch = refs/heads/master
 [submodule "parquet-cpp"]
 	path = feedstocks/parquet-cpp
 	url = https://github.com/conda-forge/parquet-cpp-feedstock.git
+	branch = refs/heads/master
 [submodule "pymbolic"]
 	path = feedstocks/pymbolic
 	url = https://github.com/conda-forge/pymbolic-feedstock.git
+	branch = refs/heads/master
 [submodule "python-utils"]
 	path = feedstocks/python-utils
 	url = https://github.com/conda-forge/python-utils-feedstock.git
+	branch = refs/heads/master
 [submodule "vs2008_express_vc_python_patch"]
 	path = feedstocks/vs2008_express_vc_python_patch
 	url = https://github.com/conda-forge/vs2008_express_vc_python_patch-feedstock.git
+	branch = refs/heads/master
 [submodule "cgen"]
 	path = feedstocks/cgen
 	url = https://github.com/conda-forge/cgen-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-funk"]
 	path = feedstocks/dask-funk
 	url = https://github.com/conda-forge/dask-funk-feedstock.git
+	branch = refs/heads/master
 [submodule "aplus"]
 	path = feedstocks/aplus
 	url = https://github.com/conda-forge/aplus-feedstock.git
+	branch = refs/heads/master
 [submodule "npctypes"]
 	path = feedstocks/npctypes
 	url = https://github.com/conda-forge/npctypes-feedstock.git
+	branch = refs/heads/master
 [submodule "ocl-icd"]
 	path = feedstocks/ocl-icd
 	url = https://github.com/conda-forge/ocl-icd-feedstock.git
+	branch = refs/heads/master
 [submodule "progressbar2"]
 	path = feedstocks/progressbar2
 	url = https://github.com/conda-forge/progressbar2-feedstock.git
+	branch = refs/heads/master
 [submodule "prometheus_client"]
 	path = feedstocks/prometheus_client
 	url = https://github.com/conda-forge/prometheus_client-feedstock.git
+	branch = refs/heads/master
 [submodule "forestci"]
 	path = feedstocks/forestci
 	url = https://github.com/conda-forge/forestci-feedstock.git
+	branch = refs/heads/master
 [submodule "sqlparse"]
 	path = feedstocks/sqlparse
 	url = https://github.com/conda-forge/sqlparse-feedstock.git
+	branch = refs/heads/master
 [submodule "chemfiles-lib"]
 	path = feedstocks/chemfiles-lib
 	url = https://github.com/conda-forge/chemfiles-lib-feedstock.git
+	branch = refs/heads/master
 [submodule "chemfiles-python"]
 	path = feedstocks/chemfiles-python
 	url = https://github.com/conda-forge/chemfiles-python-feedstock.git
+	branch = refs/heads/master
 [submodule "libflint"]
 	path = feedstocks/libflint
 	url = https://github.com/conda-forge/libflint-feedstock.git
+	branch = refs/heads/master
 [submodule "pyopencl"]
 	path = feedstocks/pyopencl
 	url = https://github.com/conda-forge/pyopencl-feedstock.git
+	branch = refs/heads/master
 [submodule "spm1d"]
 	path = feedstocks/spm1d
 	url = https://github.com/conda-forge/spm1d-feedstock.git
+	branch = refs/heads/master
 [submodule "elfutils"]
 	path = feedstocks/elfutils
 	url = https://github.com/conda-forge/elfutils-feedstock.git
+	branch = refs/heads/master
 [submodule "esgf-pyclient"]
 	path = feedstocks/esgf-pyclient
 	url = https://github.com/conda-forge/esgf-pyclient-feedstock.git
+	branch = refs/heads/master
 [submodule "ftputil"]
 	path = feedstocks/ftputil
 	url = https://github.com/conda-forge/ftputil-feedstock.git
+	branch = refs/heads/master
 [submodule "modepy"]
 	path = feedstocks/modepy
 	url = https://github.com/conda-forge/modepy-feedstock.git
+	branch = refs/heads/master
 [submodule "myproxyclient"]
 	path = feedstocks/myproxyclient
 	url = https://github.com/conda-forge/myproxyclient-feedstock.git
+	branch = refs/heads/master
 [submodule "pyopenssl"]
 	path = feedstocks/pyopenssl
 	url = https://github.com/conda-forge/pyopenssl-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-localserver"]
 	path = feedstocks/pytest-localserver
 	url = https://github.com/conda-forge/pytest-localserver-feedstock.git
+	branch = refs/heads/master
 [submodule "pyvisfile"]
 	path = feedstocks/pyvisfile
 	url = https://github.com/conda-forge/pyvisfile-feedstock.git
+	branch = refs/heads/master
 [submodule "scotch"]
 	path = feedstocks/scotch
 	url = https://github.com/conda-forge/scotch-feedstock.git
+	branch = refs/heads/master
 [submodule "shutilwhich"]
 	path = feedstocks/shutilwhich
 	url = https://github.com/conda-forge/shutilwhich-feedstock.git
+	branch = refs/heads/master
 [submodule "smart_open"]
 	path = feedstocks/smart_open
 	url = https://github.com/conda-forge/smart_open-feedstock.git
+	branch = refs/heads/master
 [submodule "arb"]
 	path = feedstocks/arb
 	url = https://github.com/conda-forge/arb-feedstock.git
+	branch = refs/heads/master
 [submodule "pyftpdlib"]
 	path = feedstocks/pyftpdlib
 	url = https://github.com/conda-forge/pyftpdlib-feedstock.git
+	branch = refs/heads/master
 [submodule "vaex"]
 	path = feedstocks/vaex
 	url = https://github.com/conda-forge/vaex-feedstock.git
+	branch = refs/heads/master
 [submodule "thermotools"]
 	path = feedstocks/thermotools
 	url = https://github.com/conda-forge/thermotools-feedstock.git
+	branch = refs/heads/master
 [submodule "chemfiles"]
 	path = feedstocks/chemfiles
 	url = https://github.com/conda-forge/chemfiles-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-migrate"]
 	path = feedstocks/flask-migrate
 	url = https://github.com/conda-forge/flask-migrate-feedstock.git
+	branch = refs/heads/master
 [submodule "libgit2"]
 	path = feedstocks/libgit2
 	url = https://github.com/conda-forge/libgit2-feedstock.git
+	branch = refs/heads/master
 [submodule "libssh2"]
 	path = feedstocks/libssh2
 	url = https://github.com/conda-forge/libssh2-feedstock.git
+	branch = refs/heads/master
 [submodule "podaacpy"]
 	path = feedstocks/podaacpy
 	url = https://github.com/conda-forge/podaacpy-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-catchlog"]
 	path = feedstocks/pytest-catchlog
 	url = https://github.com/conda-forge/pytest-catchlog-feedstock.git
+	branch = refs/heads/master
 [submodule "zconfig"]
 	path = feedstocks/zconfig
 	url = https://github.com/conda-forge/zconfig-feedstock.git
+	branch = refs/heads/master
 [submodule "cogapp"]
 	path = feedstocks/cogapp
 	url = https://github.com/conda-forge/cogapp-feedstock.git
+	branch = refs/heads/master
 [submodule "cpulimit"]
 	path = feedstocks/cpulimit
 	url = https://github.com/conda-forge/cpulimit-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-admin"]
 	path = feedstocks/flask-admin
 	url = https://github.com/conda-forge/flask-admin-feedstock.git
+	branch = refs/heads/master
 [submodule "pyarrow"]
 	path = feedstocks/pyarrow
 	url = https://github.com/conda-forge/pyarrow-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-datadir"]
 	path = feedstocks/pytest-datadir
 	url = https://github.com/conda-forge/pytest-datadir-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-timeout"]
 	path = feedstocks/pytest-timeout
 	url = https://github.com/conda-forge/pytest-timeout-feedstock.git
+	branch = refs/heads/master
 [submodule "scrapy"]
 	path = feedstocks/scrapy
 	url = https://github.com/conda-forge/scrapy-feedstock.git
+	branch = refs/heads/master
 [submodule "lazy"]
 	path = feedstocks/lazy
 	url = https://github.com/conda-forge/lazy-feedstock.git
+	branch = refs/heads/master
 [submodule "nbstripout"]
 	path = feedstocks/nbstripout
 	url = https://github.com/conda-forge/nbstripout-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-json"]
 	path = feedstocks/pytest-json
 	url = https://github.com/conda-forge/pytest-json-feedstock.git
+	branch = refs/heads/master
 [submodule "watermark"]
 	path = feedstocks/watermark
 	url = https://github.com/conda-forge/watermark-feedstock.git
+	branch = refs/heads/master
 [submodule "xnumpy"]
 	path = feedstocks/xnumpy
 	url = https://github.com/conda-forge/xnumpy-feedstock.git
+	branch = refs/heads/master
 [submodule "bhmm"]
 	path = feedstocks/bhmm
 	url = https://github.com/conda-forge/bhmm-feedstock.git
+	branch = refs/heads/master
 [submodule "hug"]
 	path = feedstocks/hug
 	url = https://github.com/conda-forge/hug-feedstock.git
+	branch = refs/heads/master
 [submodule "kuyruk"]
 	path = feedstocks/kuyruk
 	url = https://github.com/conda-forge/kuyruk-feedstock.git
+	branch = refs/heads/master
 [submodule "misaka"]
 	path = feedstocks/misaka
 	url = https://github.com/conda-forge/misaka-feedstock.git
+	branch = refs/heads/master
 [submodule "pyemma"]
 	path = feedstocks/pyemma
 	url = https://github.com/conda-forge/pyemma-feedstock.git
+	branch = refs/heads/master
 [submodule "fenics"]
 	path = feedstocks/fenics
 	url = https://github.com/conda-forge/fenics-feedstock.git
+	branch = refs/heads/master
 [submodule "mumps"]
 	path = feedstocks/mumps
 	url = https://github.com/conda-forge/mumps-feedstock.git
+	branch = refs/heads/master
 [submodule "otwrapy"]
 	path = feedstocks/otwrapy
 	url = https://github.com/conda-forge/otwrapy-feedstock.git
+	branch = refs/heads/master
 [submodule "centrally-managed-conda"]
 	path = feedstocks/centrally-managed-conda
 	url = https://github.com/conda-forge/centrally-managed-conda-feedstock.git
+	branch = refs/heads/master
 [submodule "networkx"]
 	path = feedstocks/networkx
 	url = https://github.com/conda-forge/networkx-feedstock.git
+	branch = refs/heads/master
 [submodule "pyxdameraulevenshtein"]
 	path = feedstocks/pyxdameraulevenshtein
 	url = https://github.com/conda-forge/pyxdameraulevenshtein-feedstock.git
+	branch = refs/heads/master
 [submodule "qtawesome"]
 	path = feedstocks/qtawesome
 	url = https://github.com/conda-forge/qtawesome-feedstock.git
+	branch = refs/heads/master
 [submodule "xsgen"]
 	path = feedstocks/xsgen
 	url = https://github.com/conda-forge/xsgen-feedstock.git
+	branch = refs/heads/master
 [submodule "yail"]
 	path = feedstocks/yail
 	url = https://github.com/conda-forge/yail-feedstock.git
+	branch = refs/heads/master
 [submodule "desktop3"]
 	path = feedstocks/desktop3
 	url = https://github.com/conda-forge/desktop3-feedstock.git
+	branch = refs/heads/master
 [submodule "eight"]
 	path = feedstocks/eight
 	url = https://github.com/conda-forge/eight-feedstock.git
+	branch = refs/heads/master
 [submodule "keepalive"]
 	path = feedstocks/keepalive
 	url = https://github.com/conda-forge/keepalive-feedstock.git
+	branch = refs/heads/master
 [submodule "mocsy"]
 	path = feedstocks/mocsy
 	url = https://github.com/conda-forge/mocsy-feedstock.git
+	branch = refs/heads/master
 [submodule "ocw"]
 	path = feedstocks/ocw
 	url = https://github.com/conda-forge/ocw-feedstock.git
+	branch = refs/heads/master
 [submodule "petsc"]
 	path = feedstocks/petsc
 	url = https://github.com/conda-forge/petsc-feedstock.git
+	branch = refs/heads/master
 [submodule "petsc4py"]
 	path = feedstocks/petsc4py
 	url = https://github.com/conda-forge/petsc4py-feedstock.git
+	branch = refs/heads/master
 [submodule "python-lmdb"]
 	path = feedstocks/python-lmdb
 	url = https://github.com/conda-forge/python-lmdb-feedstock.git
+	branch = refs/heads/master
 [submodule "sudospawner"]
 	path = feedstocks/sudospawner
 	url = https://github.com/conda-forge/sudospawner-feedstock.git
+	branch = refs/heads/master
 [submodule "tinyarray"]
 	path = feedstocks/tinyarray
 	url = https://github.com/conda-forge/tinyarray-feedstock.git
+	branch = refs/heads/master
 [submodule "unittest2pytest"]
 	path = feedstocks/unittest2pytest
 	url = https://github.com/conda-forge/unittest2pytest-feedstock.git
+	branch = refs/heads/master
 [submodule "ase"]
 	path = feedstocks/ase
 	url = https://github.com/conda-forge/ase-feedstock.git
+	branch = refs/heads/master
 [submodule "ciocheck"]
 	path = feedstocks/ciocheck
 	url = https://github.com/conda-forge/ciocheck-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-assets"]
 	path = feedstocks/flask-assets
 	url = https://github.com/conda-forge/flask-assets-feedstock.git
+	branch = refs/heads/master
 [submodule "ijroi"]
 	path = feedstocks/ijroi
 	url = https://github.com/conda-forge/ijroi-feedstock.git
+	branch = refs/heads/master
 [submodule "ghost.py"]
 	path = feedstocks/ghost.py
 	url = https://github.com/conda-forge/ghost.py-feedstock.git
+	branch = refs/heads/master
 [submodule "apispec"]
 	path = feedstocks/apispec
 	url = https://github.com/conda-forge/apispec-feedstock.git
+	branch = refs/heads/master
 [submodule "iteration_utilities"]
 	path = feedstocks/iteration_utilities
 	url = https://github.com/conda-forge/iteration_utilities-feedstock.git
+	branch = refs/heads/master
 [submodule "jedi"]
 	path = feedstocks/jedi
 	url = https://github.com/conda-forge/jedi-feedstock.git
+	branch = refs/heads/master
 [submodule "lektor"]
 	path = feedstocks/lektor
 	url = https://github.com/conda-forge/lektor-feedstock.git
+	branch = refs/heads/master
 [submodule "permission"]
 	path = feedstocks/permission
 	url = https://github.com/conda-forge/permission-feedstock.git
+	branch = refs/heads/master
 [submodule "webargs"]
 	path = feedstocks/webargs
 	url = https://github.com/conda-forge/webargs-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-marshmallow"]
 	path = feedstocks/flask-marshmallow
 	url = https://github.com/conda-forge/flask-marshmallow-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-restplus"]
 	path = feedstocks/flask-restplus
 	url = https://github.com/conda-forge/flask-restplus-feedstock.git
+	branch = refs/heads/master
 [submodule "marshmallow-sqlalchemy"]
 	path = feedstocks/marshmallow-sqlalchemy
 	url = https://github.com/conda-forge/marshmallow-sqlalchemy-feedstock.git
+	branch = refs/heads/master
 [submodule "pyprind"]
 	path = feedstocks/pyprind
 	url = https://github.com/conda-forge/pyprind-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-flake8"]
 	path = feedstocks/pytest-flake8
 	url = https://github.com/conda-forge/pytest-flake8-feedstock.git
+	branch = refs/heads/master
 [submodule "randomcolor"]
 	path = feedstocks/randomcolor
 	url = https://github.com/conda-forge/randomcolor-feedstock.git
+	branch = refs/heads/master
 [submodule "whoosh"]
 	path = feedstocks/whoosh
 	url = https://github.com/conda-forge/whoosh-feedstock.git
+	branch = refs/heads/master
 [submodule "imgroi"]
 	path = feedstocks/imgroi
 	url = https://github.com/conda-forge/imgroi-feedstock.git
+	branch = refs/heads/master
 [submodule "msgpack-python"]
 	path = feedstocks/msgpack-python
 	url = https://github.com/conda-forge/msgpack-python-feedstock.git
+	branch = refs/heads/master
 [submodule "probablepeople"]
 	path = feedstocks/probablepeople
 	url = https://github.com/conda-forge/probablepeople-feedstock.git
+	branch = refs/heads/master
 [submodule "sgp4"]
 	path = feedstocks/sgp4
 	url = https://github.com/conda-forge/sgp4-feedstock.git
+	branch = refs/heads/master
 [submodule "deepdish"]
 	path = feedstocks/deepdish
 	url = https://github.com/conda-forge/deepdish-feedstock.git
+	branch = refs/heads/master
 [submodule "docker-pycreds"]
 	path = feedstocks/docker-pycreds
 	url = https://github.com/conda-forge/docker-pycreds-feedstock.git
+	branch = refs/heads/master
 [submodule "coursera-dl"]
 	path = feedstocks/coursera-dl
 	url = https://github.com/conda-forge/coursera-dl-feedstock.git
+	branch = refs/heads/master
 [submodule "fastparquet"]
 	path = feedstocks/fastparquet
 	url = https://github.com/conda-forge/fastparquet-feedstock.git
+	branch = refs/heads/master
 [submodule "griddataformats"]
 	path = feedstocks/griddataformats
 	url = https://github.com/conda-forge/griddataformats-feedstock.git
+	branch = refs/heads/master
 [submodule "khronos-opencl-icd-loader"]
 	path = feedstocks/khronos-opencl-icd-loader
 	url = https://github.com/conda-forge/khronos-opencl-icd-loader-feedstock.git
+	branch = refs/heads/master
 [submodule "kwant"]
 	path = feedstocks/kwant
 	url = https://github.com/conda-forge/kwant-feedstock.git
+	branch = refs/heads/master
 [submodule "mplview"]
 	path = feedstocks/mplview
 	url = https://github.com/conda-forge/mplview-feedstock.git
+	branch = refs/heads/master
 [submodule "paver"]
 	path = feedstocks/paver
 	url = https://github.com/conda-forge/paver-feedstock.git
+	branch = refs/heads/master
 [submodule "python-dotenv"]
 	path = feedstocks/python-dotenv
 	url = https://github.com/conda-forge/python-dotenv-feedstock.git
+	branch = refs/heads/master
 [submodule "yamllint"]
 	path = feedstocks/yamllint
 	url = https://github.com/conda-forge/yamllint-feedstock.git
+	branch = refs/heads/master
 [submodule "datamountaineer-schemaregistry"]
 	path = feedstocks/datamountaineer-schemaregistry
 	url = https://github.com/conda-forge/datamountaineer-schemaregistry-feedstock.git
+	branch = refs/heads/master
 [submodule "libevent"]
 	path = feedstocks/libevent
 	url = https://github.com/conda-forge/libevent-feedstock.git
+	branch = refs/heads/master
 [submodule "cyclus-build-deps"]
 	path = feedstocks/cyclus-build-deps
 	url = https://github.com/conda-forge/cyclus-build-deps-feedstock.git
+	branch = refs/heads/master
 [submodule "fmilib"]
 	path = feedstocks/fmilib
 	url = https://github.com/conda-forge/fmilib-feedstock.git
+	branch = refs/heads/master
 [submodule "fmipp"]
 	path = feedstocks/fmipp
 	url = https://github.com/conda-forge/fmipp-feedstock.git
+	branch = refs/heads/master
 [submodule "libadjoint"]
 	path = feedstocks/libadjoint
 	url = https://github.com/conda-forge/libadjoint-feedstock.git
+	branch = refs/heads/master
 [submodule "loghub"]
 	path = feedstocks/loghub
 	url = https://github.com/conda-forge/loghub-feedstock.git
+	branch = refs/heads/master
 [submodule "salib"]
 	path = feedstocks/salib
 	url = https://github.com/conda-forge/salib-feedstock.git
+	branch = refs/heads/master
 [submodule "tmux"]
 	path = feedstocks/tmux
 	url = https://github.com/conda-forge/tmux-feedstock.git
+	branch = refs/heads/master
 [submodule "xtensor"]
 	path = feedstocks/xtensor
 	url = https://github.com/conda-forge/xtensor-feedstock.git
+	branch = refs/heads/master
 [submodule "occt"]
 	path = feedstocks/occt
 	url = https://github.com/conda-forge/occt-feedstock.git
+	branch = refs/heads/master
 [submodule "osmnx"]
 	path = feedstocks/osmnx
 	url = https://github.com/conda-forge/osmnx-feedstock.git
+	branch = refs/heads/master
 [submodule "slepc"]
 	path = feedstocks/slepc
 	url = https://github.com/conda-forge/slepc-feedstock.git
+	branch = refs/heads/master
 [submodule "slepc4py"]
 	path = feedstocks/slepc4py
 	url = https://github.com/conda-forge/slepc4py-feedstock.git
+	branch = refs/heads/master
 [submodule "boto3"]
 	path = feedstocks/boto3
 	url = https://github.com/conda-forge/boto3-feedstock.git
+	branch = refs/heads/master
 [submodule "jobtastic"]
 	path = feedstocks/jobtastic
 	url = https://github.com/conda-forge/jobtastic-feedstock.git
+	branch = refs/heads/master
 [submodule "librabbitmq"]
 	path = feedstocks/librabbitmq
 	url = https://github.com/conda-forge/librabbitmq-feedstock.git
+	branch = refs/heads/master
 [submodule "dbf"]
 	path = feedstocks/dbf
 	url = https://github.com/conda-forge/dbf-feedstock.git
+	branch = refs/heads/master
 [submodule "assimulo"]
 	path = feedstocks/assimulo
 	url = https://github.com/conda-forge/assimulo-feedstock.git
+	branch = refs/heads/master
 [submodule "django-nested-admin"]
 	path = feedstocks/django-nested-admin
 	url = https://github.com/conda-forge/django-nested-admin-feedstock.git
+	branch = refs/heads/master
 [submodule "ndarray_listener"]
 	path = feedstocks/ndarray_listener
 	url = https://github.com/conda-forge/ndarray_listener-feedstock.git
+	branch = refs/heads/master
 [submodule "py_gd"]
 	path = feedstocks/py_gd
 	url = https://github.com/conda-forge/py_gd-feedstock.git
+	branch = refs/heads/master
 [submodule "pyfai"]
 	path = feedstocks/pyfai
 	url = https://github.com/conda-forge/pyfai-feedstock.git
+	branch = refs/heads/master
 [submodule "python-monkey-business"]
 	path = feedstocks/python-monkey-business
 	url = https://github.com/conda-forge/python-monkey-business-feedstock.git
+	branch = refs/heads/master
 [submodule "skan"]
 	path = feedstocks/skan
 	url = https://github.com/conda-forge/skan-feedstock.git
+	branch = refs/heads/master
 [submodule "fastcluster"]
 	path = feedstocks/fastcluster
 	url = https://github.com/conda-forge/fastcluster-feedstock.git
+	branch = refs/heads/master
 [submodule "pyfmi"]
 	path = feedstocks/pyfmi
 	url = https://github.com/conda-forge/pyfmi-feedstock.git
+	branch = refs/heads/master
 [submodule "brent_search"]
 	path = feedstocks/brent_search
 	url = https://github.com/conda-forge/brent_search-feedstock.git
+	branch = refs/heads/master
 [submodule "dbt"]
 	path = feedstocks/dbt
 	url = https://github.com/conda-forge/dbt-feedstock.git
+	branch = refs/heads/master
 [submodule "ecm"]
 	path = feedstocks/ecm
 	url = https://github.com/conda-forge/ecm-feedstock.git
+	branch = refs/heads/master
 [submodule "memprof"]
 	path = feedstocks/memprof
 	url = https://github.com/conda-forge/memprof-feedstock.git
+	branch = refs/heads/master
 [submodule "multiprocess"]
 	path = feedstocks/multiprocess
 	url = https://github.com/conda-forge/multiprocess-feedstock.git
+	branch = refs/heads/master
 [submodule "pathos"]
 	path = feedstocks/pathos
 	url = https://github.com/conda-forge/pathos-feedstock.git
+	branch = refs/heads/master
 [submodule "pox"]
 	path = feedstocks/pox
 	url = https://github.com/conda-forge/pox-feedstock.git
+	branch = refs/heads/master
 [submodule "ppft"]
 	path = feedstocks/ppft
 	url = https://github.com/conda-forge/ppft-feedstock.git
+	branch = refs/heads/master
 [submodule "ampl-mp"]
 	path = feedstocks/ampl-mp
 	url = https://github.com/conda-forge/ampl-mp-feedstock.git
+	branch = refs/heads/master
 [submodule "asap"]
 	path = feedstocks/asap
 	url = https://github.com/conda-forge/asap-feedstock.git
+	branch = refs/heads/master
 [submodule "dolfin-adjoint"]
 	path = feedstocks/dolfin-adjoint
 	url = https://github.com/conda-forge/dolfin-adjoint-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-openid"]
 	path = feedstocks/flask-openid
 	url = https://github.com/conda-forge/flask-openid-feedstock.git
+	branch = refs/heads/master
 [submodule "mono"]
 	path = feedstocks/mono
 	url = https://github.com/conda-forge/mono-feedstock.git
+	branch = refs/heads/master
 [submodule "piranha"]
 	path = feedstocks/piranha
 	url = https://github.com/conda-forge/piranha-feedstock.git
+	branch = refs/heads/master
 [submodule "re2"]
 	path = feedstocks/re2
 	url = https://github.com/conda-forge/re2-feedstock.git
+	branch = refs/heads/master
 [submodule "regolith"]
 	path = feedstocks/regolith
 	url = https://github.com/conda-forge/regolith-feedstock.git
+	branch = refs/heads/master
 [submodule "build_capi"]
 	path = feedstocks/build_capi
 	url = https://github.com/conda-forge/build_capi-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-gitenv"]
 	path = feedstocks/conda-gitenv
 	url = https://github.com/conda-forge/conda-gitenv-feedstock.git
+	branch = refs/heads/master
 [submodule "optimix"]
 	path = feedstocks/optimix
 	url = https://github.com/conda-forge/optimix-feedstock.git
+	branch = refs/heads/master
 [submodule "pyxb"]
 	path = feedstocks/pyxb
 	url = https://github.com/conda-forge/pyxb-feedstock.git
+	branch = refs/heads/master
 [submodule "coinmp"]
 	path = feedstocks/coinmp
 	url = https://github.com/conda-forge/coinmp-feedstock.git
+	branch = refs/heads/master
 [submodule "extinction"]
 	path = feedstocks/extinction
 	url = https://github.com/conda-forge/extinction-feedstock.git
+	branch = refs/heads/master
 [submodule "py"]
 	path = feedstocks/py
 	url = https://github.com/conda-forge/py-feedstock.git
+	branch = refs/heads/master
 [submodule "xtensor-python"]
 	path = feedstocks/xtensor-python
 	url = https://github.com/conda-forge/xtensor-python-feedstock.git
+	branch = refs/heads/master
 [submodule "attrs-sqlalchemy"]
 	path = feedstocks/attrs-sqlalchemy
 	url = https://github.com/conda-forge/attrs-sqlalchemy-feedstock.git
+	branch = refs/heads/master
 [submodule "cairocffi"]
 	path = feedstocks/cairocffi
 	url = https://github.com/conda-forge/cairocffi-feedstock.git
+	branch = refs/heads/master
 [submodule "cairosvg"]
 	path = feedstocks/cairosvg
 	url = https://github.com/conda-forge/cairosvg-feedstock.git
+	branch = refs/heads/master
 [submodule "discretizer"]
 	path = feedstocks/discretizer
 	url = https://github.com/conda-forge/discretizer-feedstock.git
+	branch = refs/heads/master
 [submodule "django-filter"]
 	path = feedstocks/django-filter
 	url = https://github.com/conda-forge/django-filter-feedstock.git
+	branch = refs/heads/master
 [submodule "skyfield"]
 	path = feedstocks/skyfield
 	url = https://github.com/conda-forge/skyfield-feedstock.git
+	branch = refs/heads/master
 [submodule "tinycss"]
 	path = feedstocks/tinycss
 	url = https://github.com/conda-forge/tinycss-feedstock.git
+	branch = refs/heads/master
 [submodule "djangorestframework-gis"]
 	path = feedstocks/djangorestframework-gis
 	url = https://github.com/conda-forge/djangorestframework-gis-feedstock.git
+	branch = refs/heads/master
 [submodule "ncl"]
 	path = feedstocks/ncl
 	url = https://github.com/conda-forge/ncl-feedstock.git
+	branch = refs/heads/master
 [submodule "iowait"]
 	path = feedstocks/iowait
 	url = https://github.com/conda-forge/iowait-feedstock.git
+	branch = refs/heads/master
 [submodule "nestly"]
 	path = feedstocks/nestly
 	url = https://github.com/conda-forge/nestly-feedstock.git
+	branch = refs/heads/master
 [submodule "otlm"]
 	path = feedstocks/otlm
 	url = https://github.com/conda-forge/otlm-feedstock.git
+	branch = refs/heads/master
 [submodule "spglib"]
 	path = feedstocks/spglib
 	url = https://github.com/conda-forge/spglib-feedstock.git
+	branch = refs/heads/master
 [submodule "circus"]
 	path = feedstocks/circus
 	url = https://github.com/conda-forge/circus-feedstock.git
+	branch = refs/heads/master
 [submodule "docx2txt"]
 	path = feedstocks/docx2txt
 	url = https://github.com/conda-forge/docx2txt-feedstock.git
+	branch = refs/heads/master
 [submodule "libglu"]
 	path = feedstocks/libglu
 	url = https://github.com/conda-forge/libglu-feedstock.git
+	branch = refs/heads/master
 [submodule "ncephes"]
 	path = feedstocks/ncephes
 	url = https://github.com/conda-forge/ncephes-feedstock.git
+	branch = refs/heads/master
 [submodule "pyorgmode"]
 	path = feedstocks/pyorgmode
 	url = https://github.com/conda-forge/pyorgmode-feedstock.git
+	branch = refs/heads/master
 [submodule "celiagg"]
 	path = feedstocks/celiagg
 	url = https://github.com/conda-forge/celiagg-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-import-order"]
 	path = feedstocks/flake8-import-order
 	url = https://github.com/conda-forge/flake8-import-order-feedstock.git
+	branch = refs/heads/master
 [submodule "libjpeg-turbo"]
 	path = feedstocks/libjpeg-turbo
 	url = https://github.com/conda-forge/libjpeg-turbo-feedstock.git
+	branch = refs/heads/master
 [submodule "nbsphinx"]
 	path = feedstocks/nbsphinx
 	url = https://github.com/conda-forge/nbsphinx-feedstock.git
+	branch = refs/heads/master
 [submodule "numpy_sugar"]
 	path = feedstocks/numpy_sugar
 	url = https://github.com/conda-forge/numpy_sugar-feedstock.git
+	branch = refs/heads/master
 [submodule "pysdl2"]
 	path = feedstocks/pysdl2
 	url = https://github.com/conda-forge/pysdl2-feedstock.git
+	branch = refs/heads/master
 [submodule "sdl2"]
 	path = feedstocks/sdl2
 	url = https://github.com/conda-forge/sdl2-feedstock.git
+	branch = refs/heads/master
 [submodule "txaio"]
 	path = feedstocks/txaio
 	url = https://github.com/conda-forge/txaio-feedstock.git
+	branch = refs/heads/master
 [submodule "anyqt"]
 	path = feedstocks/anyqt
 	url = https://github.com/conda-forge/anyqt-feedstock.git
+	branch = refs/heads/master
 [submodule "autobahn"]
 	path = feedstocks/autobahn
 	url = https://github.com/conda-forge/autobahn-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-builtins"]
 	path = feedstocks/flake8-builtins
 	url = https://github.com/conda-forge/flake8-builtins-feedstock.git
+	branch = refs/heads/master
 [submodule "imagehash"]
 	path = feedstocks/imagehash
 	url = https://github.com/conda-forge/imagehash-feedstock.git
+	branch = refs/heads/master
 [submodule "pyranha"]
 	path = feedstocks/pyranha
 	url = https://github.com/conda-forge/pyranha-feedstock.git
+	branch = refs/heads/master
 [submodule "bagit"]
 	path = feedstocks/bagit
 	url = https://github.com/conda-forge/bagit-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-comprehensions"]
 	path = feedstocks/flake8-comprehensions
 	url = https://github.com/conda-forge/flake8-comprehensions-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-mutable"]
 	path = feedstocks/flake8-mutable
 	url = https://github.com/conda-forge/flake8-mutable-feedstock.git
+	branch = refs/heads/master
 [submodule "treq"]
 	path = feedstocks/treq
 	url = https://github.com/conda-forge/treq-feedstock.git
+	branch = refs/heads/master
 [submodule "wsaccel"]
 	path = feedstocks/wsaccel
 	url = https://github.com/conda-forge/wsaccel-feedstock.git
+	branch = refs/heads/master
 [submodule "django-admin-shortcuts"]
 	path = feedstocks/django-admin-shortcuts
 	url = https://github.com/conda-forge/django-admin-shortcuts-feedstock.git
+	branch = refs/heads/master
 [submodule "django-ajax-selects"]
 	path = feedstocks/django-ajax-selects
 	url = https://github.com/conda-forge/django-ajax-selects-feedstock.git
+	branch = refs/heads/master
 [submodule "django-apptemplates"]
 	path = feedstocks/django-apptemplates
 	url = https://github.com/conda-forge/django-apptemplates-feedstock.git
+	branch = refs/heads/master
 [submodule "django-uuidfield"]
 	path = feedstocks/django-uuidfield
 	url = https://github.com/conda-forge/django-uuidfield-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-copyright"]
 	path = feedstocks/flake8-copyright
 	url = https://github.com/conda-forge/flake8-copyright-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-pep3101"]
 	path = feedstocks/flake8-pep3101
 	url = https://github.com/conda-forge/flake8-pep3101-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-print"]
 	path = feedstocks/flake8-print
 	url = https://github.com/conda-forge/flake8-print-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_latex_envs"]
 	path = feedstocks/jupyter_latex_envs
 	url = https://github.com/conda-forge/jupyter_latex_envs-feedstock.git
+	branch = refs/heads/master
 [submodule "mmtf-python"]
 	path = feedstocks/mmtf-python
 	url = https://github.com/conda-forge/mmtf-python-feedstock.git
+	branch = refs/heads/master
 [submodule "diff-match-patch"]
 	path = feedstocks/diff-match-patch
 	url = https://github.com/conda-forge/diff-match-patch-feedstock.git
+	branch = refs/heads/master
 [submodule "django-daterange-filter"]
 	path = feedstocks/django-daterange-filter
 	url = https://github.com/conda-forge/django-daterange-filter-feedstock.git
+	branch = refs/heads/master
 [submodule "django-import-export"]
 	path = feedstocks/django-import-export
 	url = https://github.com/conda-forge/django-import-export-feedstock.git
+	branch = refs/heads/master
 [submodule "django-jquery"]
 	path = feedstocks/django-jquery
 	url = https://github.com/conda-forge/django-jquery-feedstock.git
+	branch = refs/heads/master
 [submodule "djangocms-admin-style"]
 	path = feedstocks/djangocms-admin-style
 	url = https://github.com/conda-forge/djangocms-admin-style-feedstock.git
+	branch = refs/heads/master
 [submodule "dmd"]
 	path = feedstocks/dmd
 	url = https://github.com/conda-forge/dmd-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-docstrings"]
 	path = feedstocks/flake8-docstrings
 	url = https://github.com/conda-forge/flake8-docstrings-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-polyfill"]
 	path = feedstocks/flake8-polyfill
 	url = https://github.com/conda-forge/flake8-polyfill-feedstock.git
+	branch = refs/heads/master
 [submodule "pyngl"]
 	path = feedstocks/pyngl
 	url = https://github.com/conda-forge/pyngl-feedstock.git
+	branch = refs/heads/master
 [submodule "tablib"]
 	path = feedstocks/tablib
 	url = https://github.com/conda-forge/tablib-feedstock.git
+	branch = refs/heads/master
 [submodule "obspyck"]
 	path = feedstocks/obspyck
 	url = https://github.com/conda-forge/obspyck-feedstock.git
+	branch = refs/heads/master
 [submodule "fish"]
 	path = feedstocks/fish
 	url = https://github.com/conda-forge/fish-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_highlight_selected_word"]
 	path = feedstocks/jupyter_highlight_selected_word
 	url = https://github.com/conda-forge/jupyter_highlight_selected_word-feedstock.git
+	branch = refs/heads/master
 [submodule "pydispatcher"]
 	path = feedstocks/pydispatcher
 	url = https://github.com/conda-forge/pydispatcher-feedstock.git
+	branch = refs/heads/master
 [submodule "backward-cpp"]
 	path = feedstocks/backward-cpp
 	url = https://github.com/conda-forge/backward-cpp-feedstock.git
+	branch = refs/heads/master
 [submodule "chai"]
 	path = feedstocks/chai
 	url = https://github.com/conda-forge/chai-feedstock.git
+	branch = refs/heads/master
 [submodule "cysignals"]
 	path = feedstocks/cysignals
 	url = https://github.com/conda-forge/cysignals-feedstock.git
+	branch = refs/heads/master
 [submodule "doconce"]
 	path = feedstocks/doconce
 	url = https://github.com/conda-forge/doconce-feedstock.git
+	branch = refs/heads/master
 [submodule "git-lfs"]
 	path = feedstocks/git-lfs
 	url = https://github.com/conda-forge/git-lfs-feedstock.git
+	branch = refs/heads/master
 [submodule "glob2"]
 	path = feedstocks/glob2
 	url = https://github.com/conda-forge/glob2-feedstock.git
+	branch = refs/heads/master
 [submodule "gnuplot"]
 	path = feedstocks/gnuplot
 	url = https://github.com/conda-forge/gnuplot-feedstock.git
+	branch = refs/heads/master
 [submodule "go-spatial"]
 	path = feedstocks/go-spatial
 	url = https://github.com/conda-forge/go-spatial-feedstock.git
+	branch = refs/heads/master
 [submodule "help2man"]
 	path = feedstocks/help2man
 	url = https://github.com/conda-forge/help2man-feedstock.git
+	branch = refs/heads/master
 [submodule "keyrings.alt"]
 	path = feedstocks/keyrings.alt
 	url = https://github.com/conda-forge/keyrings.alt-feedstock.git
+	branch = refs/heads/master
 [submodule "libconfig"]
 	path = feedstocks/libconfig
 	url = https://github.com/conda-forge/libconfig-feedstock.git
+	branch = refs/heads/master
 [submodule "librdkafka"]
 	path = feedstocks/librdkafka
 	url = https://github.com/conda-forge/librdkafka-feedstock.git
+	branch = refs/heads/master
 [submodule "libuv"]
 	path = feedstocks/libuv
 	url = https://github.com/conda-forge/libuv-feedstock.git
+	branch = refs/heads/master
 [submodule "mosh"]
 	path = feedstocks/mosh
 	url = https://github.com/conda-forge/mosh-feedstock.git
+	branch = refs/heads/master
 [submodule "nanoflann"]
 	path = feedstocks/nanoflann
 	url = https://github.com/conda-forge/nanoflann-feedstock.git
+	branch = refs/heads/master
 [submodule "openjdk"]
 	path = feedstocks/openjdk
 	url = https://github.com/conda-forge/openjdk-feedstock.git
+	branch = refs/heads/master
 [submodule "plumbum"]
 	path = feedstocks/plumbum
 	url = https://github.com/conda-forge/plumbum-feedstock.git
+	branch = refs/heads/master
 [submodule "pweave"]
 	path = feedstocks/pweave
 	url = https://github.com/conda-forge/pweave-feedstock.git
+	branch = refs/heads/master
 [submodule "pygypsy"]
 	path = feedstocks/pygypsy
 	url = https://github.com/conda-forge/pygypsy-feedstock.git
+	branch = refs/heads/master
 [submodule "pyreadline"]
 	path = feedstocks/pyreadline
 	url = https://github.com/conda-forge/pyreadline-feedstock.git
+	branch = refs/heads/master
 [submodule "python-graphviz"]
 	path = feedstocks/python-graphviz
 	url = https://github.com/conda-forge/python-graphviz-feedstock.git
+	branch = refs/heads/master
 [submodule "read-roi"]
 	path = feedstocks/read-roi
 	url = https://github.com/conda-forge/read-roi-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-build"]
 	path = feedstocks/scikit-build
 	url = https://github.com/conda-forge/scikit-build-feedstock.git
+	branch = refs/heads/master
 [submodule "sfepy"]
 	path = feedstocks/sfepy
 	url = https://github.com/conda-forge/sfepy-feedstock.git
+	branch = refs/heads/master
 [submodule "sortedcollections"]
 	path = feedstocks/sortedcollections
 	url = https://github.com/conda-forge/sortedcollections-feedstock.git
+	branch = refs/heads/master
 [submodule "sparqlwrapper"]
 	path = feedstocks/sparqlwrapper
 	url = https://github.com/conda-forge/sparqlwrapper-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxcontrib-paverutils"]
 	path = feedstocks/sphinxcontrib-paverutils
 	url = https://github.com/conda-forge/sphinxcontrib-paverutils-feedstock.git
+	branch = refs/heads/master
 [submodule "tyssue"]
 	path = feedstocks/tyssue
 	url = https://github.com/conda-forge/tyssue-feedstock.git
+	branch = refs/heads/master
 [submodule "cquadpack"]
 	path = feedstocks/cquadpack
 	url = https://github.com/conda-forge/cquadpack-feedstock.git
+	branch = refs/heads/master
 [submodule "glew"]
 	path = feedstocks/glew
 	url = https://github.com/conda-forge/glew-feedstock.git
+	branch = refs/heads/master
 [submodule "ninja_syntax"]
 	path = feedstocks/ninja_syntax
 	url = https://github.com/conda-forge/ninja_syntax-feedstock.git
+	branch = refs/heads/master
 [submodule "nose-cov"]
 	path = feedstocks/nose-cov
 	url = https://github.com/conda-forge/nose-cov-feedstock.git
+	branch = refs/heads/master
 [submodule "nr"]
 	path = feedstocks/nr
 	url = https://github.com/conda-forge/nr-feedstock.git
+	branch = refs/heads/master
 [submodule "pandocfilters"]
 	path = feedstocks/pandocfilters
 	url = https://github.com/conda-forge/pandocfilters-feedstock.git
+	branch = refs/heads/master
 [submodule "brent-search"]
 	path = feedstocks/brent-search
 	url = https://github.com/conda-forge/brent-search-feedstock.git
+	branch = refs/heads/master
 [submodule "build-capi"]
 	path = feedstocks/build-capi
 	url = https://github.com/conda-forge/build-capi-feedstock.git
+	branch = refs/heads/master
 [submodule "libmad"]
 	path = feedstocks/libmad
 	url = https://github.com/conda-forge/libmad-feedstock.git
+	branch = refs/heads/master
 [submodule "libogg"]
 	path = feedstocks/libogg
 	url = https://github.com/conda-forge/libogg-feedstock.git
+	branch = refs/heads/master
 [submodule "r-base"]
 	path = feedstocks/r-base
 	url = https://github.com/conda-forge/r-base-feedstock.git
+	branch = refs/heads/master
 [submodule "sdl2_gfx"]
 	path = feedstocks/sdl2_gfx
 	url = https://github.com/conda-forge/sdl2_gfx-feedstock.git
+	branch = refs/heads/master
 [submodule "sdl2_net"]
 	path = feedstocks/sdl2_net
 	url = https://github.com/conda-forge/sdl2_net-feedstock.git
+	branch = refs/heads/master
 [submodule "signac"]
 	path = feedstocks/signac
 	url = https://github.com/conda-forge/signac-feedstock.git
+	branch = refs/heads/master
 [submodule "smpeg2"]
 	path = feedstocks/smpeg2
 	url = https://github.com/conda-forge/smpeg2-feedstock.git
+	branch = refs/heads/master
 [submodule "xerces-c28"]
 	path = feedstocks/xerces-c28
 	url = https://github.com/conda-forge/xerces-c28-feedstock.git
+	branch = refs/heads/master
 [submodule "brotli"]
 	path = feedstocks/brotli
 	url = https://github.com/conda-forge/brotli-feedstock.git
+	branch = refs/heads/master
 [submodule "cfitsio"]
 	path = feedstocks/cfitsio
 	url = https://github.com/conda-forge/cfitsio-feedstock.git
+	branch = refs/heads/master
 [submodule "curio"]
 	path = feedstocks/curio
 	url = https://github.com/conda-forge/curio-feedstock.git
+	branch = refs/heads/master
 [submodule "libvorbis"]
 	path = feedstocks/libvorbis
 	url = https://github.com/conda-forge/libvorbis-feedstock.git
+	branch = refs/heads/master
 [submodule "libwebp"]
 	path = feedstocks/libwebp
 	url = https://github.com/conda-forge/libwebp-feedstock.git
+	branch = refs/heads/master
 [submodule "lime"]
 	path = feedstocks/lime
 	url = https://github.com/conda-forge/lime-feedstock.git
+	branch = refs/heads/master
 [submodule "mechanicalsoup"]
 	path = feedstocks/mechanicalsoup
 	url = https://github.com/conda-forge/mechanicalsoup-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-plink"]
 	path = feedstocks/pandas-plink
 	url = https://github.com/conda-forge/pandas-plink-feedstock.git
+	branch = refs/heads/master
 [submodule "phonopy"]
 	path = feedstocks/phonopy
 	url = https://github.com/conda-forge/phonopy-feedstock.git
+	branch = refs/heads/master
 [submodule "sdl2_ttf"]
 	path = feedstocks/sdl2_ttf
 	url = https://github.com/conda-forge/sdl2_ttf-feedstock.git
+	branch = refs/heads/master
 [submodule "setuptools_scm_git_archive"]
 	path = feedstocks/setuptools_scm_git_archive
 	url = https://github.com/conda-forge/setuptools_scm_git_archive-feedstock.git
+	branch = refs/heads/master
 [submodule "sqlalchemy-redshift"]
 	path = feedstocks/sqlalchemy-redshift
 	url = https://github.com/conda-forge/sqlalchemy-redshift-feedstock.git
+	branch = refs/heads/master
 [submodule "watchtower"]
 	path = feedstocks/watchtower
 	url = https://github.com/conda-forge/watchtower-feedstock.git
+	branch = refs/heads/master
 [submodule "dbus-cxx"]
 	path = feedstocks/dbus-cxx
 	url = https://github.com/conda-forge/dbus-cxx-feedstock.git
+	branch = refs/heads/master
 [submodule "mpifft4py"]
 	path = feedstocks/mpifft4py
 	url = https://github.com/conda-forge/mpifft4py-feedstock.git
+	branch = refs/heads/master
 [submodule "nbtutor"]
 	path = feedstocks/nbtutor
 	url = https://github.com/conda-forge/nbtutor-feedstock.git
+	branch = refs/heads/master
 [submodule "shapelib"]
 	path = feedstocks/shapelib
 	url = https://github.com/conda-forge/shapelib-feedstock.git
+	branch = refs/heads/master
 [submodule "biopandas"]
 	path = feedstocks/biopandas
 	url = https://github.com/conda-forge/biopandas-feedstock.git
+	branch = refs/heads/master
 [submodule "libflac"]
 	path = feedstocks/libflac
 	url = https://github.com/conda-forge/libflac-feedstock.git
+	branch = refs/heads/master
 [submodule "liknorm"]
 	path = feedstocks/liknorm
 	url = https://github.com/conda-forge/liknorm-feedstock.git
+	branch = refs/heads/master
 [submodule "limix-inference"]
 	path = feedstocks/limix-inference
 	url = https://github.com/conda-forge/limix-inference-feedstock.git
+	branch = refs/heads/master
 [submodule "cligj"]
 	path = feedstocks/cligj
 	url = https://github.com/conda-forge/cligj-feedstock.git
+	branch = refs/heads/master
 [submodule "engarde"]
 	path = feedstocks/engarde
 	url = https://github.com/conda-forge/engarde-feedstock.git
+	branch = refs/heads/master
 [submodule "octave_kernel"]
 	path = feedstocks/octave_kernel
 	url = https://github.com/conda-forge/octave_kernel-feedstock.git
+	branch = refs/heads/master
 [submodule "pugixml"]
 	path = feedstocks/pugixml
 	url = https://github.com/conda-forge/pugixml-feedstock.git
+	branch = refs/heads/master
 [submodule "backports.shutil_which"]
 	path = feedstocks/backports.shutil_which
 	url = https://github.com/conda-forge/backports.shutil_which-feedstock.git
+	branch = refs/heads/master
 [submodule "monty"]
 	path = feedstocks/monty
 	url = https://github.com/conda-forge/monty-feedstock.git
+	branch = refs/heads/master
 [submodule "websockets"]
 	path = feedstocks/websockets
 	url = https://github.com/conda-forge/websockets-feedstock.git
+	branch = refs/heads/master
 [submodule "nbdime"]
 	path = feedstocks/nbdime
 	url = https://github.com/conda-forge/nbdime-feedstock.git
+	branch = refs/heads/master
 [submodule "crick"]
 	path = feedstocks/crick
 	url = https://github.com/conda-forge/crick-feedstock.git
+	branch = refs/heads/master
 [submodule "imageio"]
 	path = feedstocks/imageio
 	url = https://github.com/conda-forge/imageio-feedstock.git
+	branch = refs/heads/master
 [submodule "sqlalchemy"]
 	path = feedstocks/sqlalchemy
 	url = https://github.com/conda-forge/sqlalchemy-feedstock.git
+	branch = refs/heads/master
 [submodule "asv"]
 	path = feedstocks/asv
 	url = https://github.com/conda-forge/asv-feedstock.git
+	branch = refs/heads/master
 [submodule "calliope"]
 	path = feedstocks/calliope
 	url = https://github.com/conda-forge/calliope-feedstock.git
+	branch = refs/heads/master
 [submodule "hkdf"]
 	path = feedstocks/hkdf
 	url = https://github.com/conda-forge/hkdf-feedstock.git
+	branch = refs/heads/master
 [submodule "jemalloc"]
 	path = feedstocks/jemalloc
 	url = https://github.com/conda-forge/jemalloc-feedstock.git
+	branch = refs/heads/master
 [submodule "libcmaes"]
 	path = feedstocks/libcmaes
 	url = https://github.com/conda-forge/libcmaes-feedstock.git
+	branch = refs/heads/master
 [submodule "pygit2"]
 	path = feedstocks/pygit2
 	url = https://github.com/conda-forge/pygit2-feedstock.git
+	branch = refs/heads/master
 [submodule "python-rapidjson"]
 	path = feedstocks/python-rapidjson
 	url = https://github.com/conda-forge/python-rapidjson-feedstock.git
+	branch = refs/heads/master
 [submodule "pyvisa-py"]
 	path = feedstocks/pyvisa-py
 	url = https://github.com/conda-forge/pyvisa-py-feedstock.git
+	branch = refs/heads/master
 [submodule "sdl2_mixer"]
 	path = feedstocks/sdl2_mixer
 	url = https://github.com/conda-forge/sdl2_mixer-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxjp.themes.solarized"]
 	path = feedstocks/sphinxjp.themes.solarized
 	url = https://github.com/conda-forge/sphinxjp.themes.solarized-feedstock.git
+	branch = refs/heads/master
 [submodule "doxygen"]
 	path = feedstocks/doxygen
 	url = https://github.com/conda-forge/doxygen-feedstock.git
+	branch = refs/heads/master
 [submodule "georaster"]
 	path = feedstocks/georaster
 	url = https://github.com/conda-forge/georaster-feedstock.git
+	branch = refs/heads/master
 [submodule "markdown-checklist"]
 	path = feedstocks/markdown-checklist
 	url = https://github.com/conda-forge/markdown-checklist-feedstock.git
+	branch = refs/heads/master
 [submodule "python-markdown-math"]
 	path = feedstocks/python-markdown-math
 	url = https://github.com/conda-forge/python-markdown-math-feedstock.git
+	branch = refs/heads/master
 [submodule "boost-cpp"]
 	path = feedstocks/boost-cpp
 	url = https://github.com/conda-forge/boost-cpp-feedstock.git
+	branch = refs/heads/master
 [submodule "libtheora"]
 	path = feedstocks/libtheora
 	url = https://github.com/conda-forge/libtheora-feedstock.git
+	branch = refs/heads/master
 [submodule "lp_solve"]
 	path = feedstocks/lp_solve
 	url = https://github.com/conda-forge/lp_solve-feedstock.git
+	branch = refs/heads/master
 [submodule "ply"]
 	path = feedstocks/ply
 	url = https://github.com/conda-forge/ply-feedstock.git
+	branch = refs/heads/master
 [submodule "sdl2_image"]
 	path = feedstocks/sdl2_image
 	url = https://github.com/conda-forge/sdl2_image-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxcontrib-autodoc_doxygen"]
 	path = feedstocks/sphinxcontrib-autodoc_doxygen
 	url = https://github.com/conda-forge/sphinxcontrib-autodoc_doxygen-feedstock.git
+	branch = refs/heads/master
 [submodule "vifm"]
 	path = feedstocks/vifm
 	url = https://github.com/conda-forge/vifm-feedstock.git
+	branch = refs/heads/master
 [submodule "igraph"]
 	path = feedstocks/igraph
 	url = https://github.com/conda-forge/igraph-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-spec"]
 	path = feedstocks/pytest-spec
 	url = https://github.com/conda-forge/pytest-spec-feedstock.git
+	branch = refs/heads/master
 [submodule "python-igraph"]
 	path = feedstocks/python-igraph
 	url = https://github.com/conda-forge/python-igraph-feedstock.git
+	branch = refs/heads/master
 [submodule "bleach"]
 	path = feedstocks/bleach
 	url = https://github.com/conda-forge/bleach-feedstock.git
+	branch = refs/heads/master
 [submodule "cffi"]
 	path = feedstocks/cffi
 	url = https://github.com/conda-forge/cffi-feedstock.git
+	branch = refs/heads/master
 [submodule "cymetric"]
 	path = feedstocks/cymetric
 	url = https://github.com/conda-forge/cymetric-feedstock.git
+	branch = refs/heads/master
 [submodule "preprocess"]
 	path = feedstocks/preprocess
 	url = https://github.com/conda-forge/preprocess-feedstock.git
+	branch = refs/heads/master
 [submodule "alps"]
 	path = feedstocks/alps
 	url = https://github.com/conda-forge/alps-feedstock.git
+	branch = refs/heads/master
 [submodule "coveralls"]
 	path = feedstocks/coveralls
 	url = https://github.com/conda-forge/coveralls-feedstock.git
+	branch = refs/heads/master
 [submodule "mysql-connector-c"]
 	path = feedstocks/mysql-connector-c
 	url = https://github.com/conda-forge/mysql-connector-c-feedstock.git
+	branch = refs/heads/master
 [submodule "nbgrader"]
 	path = feedstocks/nbgrader
 	url = https://github.com/conda-forge/nbgrader-feedstock.git
+	branch = refs/heads/master
 [submodule "numpydoc"]
 	path = feedstocks/numpydoc
 	url = https://github.com/conda-forge/numpydoc-feedstock.git
+	branch = refs/heads/master
 [submodule "polcart"]
 	path = feedstocks/polcart
 	url = https://github.com/conda-forge/polcart-feedstock.git
+	branch = refs/heads/master
 [submodule "django-recaptcha"]
 	path = feedstocks/django-recaptcha
 	url = https://github.com/conda-forge/django-recaptcha-feedstock.git
+	branch = refs/heads/master
 [submodule "elastic"]
 	path = feedstocks/elastic
 	url = https://github.com/conda-forge/elastic-feedstock.git
+	branch = refs/heads/master
 [submodule "pyqtgraph"]
 	path = feedstocks/pyqtgraph
 	url = https://github.com/conda-forge/pyqtgraph-feedstock.git
+	branch = refs/heads/master
 [submodule "rpfits"]
 	path = feedstocks/rpfits
 	url = https://github.com/conda-forge/rpfits-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx-gallery"]
 	path = feedstocks/sphinx-gallery
 	url = https://github.com/conda-forge/sphinx-gallery-feedstock.git
+	branch = refs/heads/master
 [submodule "astropy"]
 	path = feedstocks/astropy
 	url = https://github.com/conda-forge/astropy-feedstock.git
+	branch = refs/heads/master
 [submodule "bunch"]
 	path = feedstocks/bunch
 	url = https://github.com/conda-forge/bunch-feedstock.git
+	branch = refs/heads/master
 [submodule "nxviz"]
 	path = feedstocks/nxviz
 	url = https://github.com/conda-forge/nxviz-feedstock.git
+	branch = refs/heads/master
 [submodule "pony"]
 	path = feedstocks/pony
 	url = https://github.com/conda-forge/pony-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xproto"]
 	path = feedstocks/xorg-xproto
 	url = https://github.com/conda-forge/xorg-xproto-feedstock.git
+	branch = refs/heads/master
 [submodule "wcslib"]
 	path = feedstocks/wcslib
 	url = https://github.com/conda-forge/wcslib-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-fixesproto"]
 	path = feedstocks/xorg-fixesproto
 	url = https://github.com/conda-forge/xorg-fixesproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-inputproto"]
 	path = feedstocks/xorg-inputproto
 	url = https://github.com/conda-forge/xorg-inputproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-util-macros"]
 	path = feedstocks/xorg-util-macros
 	url = https://github.com/conda-forge/xorg-util-macros-feedstock.git
+	branch = refs/heads/master
 [submodule "convertdate"]
 	path = feedstocks/convertdate
 	url = https://github.com/conda-forge/convertdate-feedstock.git
+	branch = refs/heads/master
 [submodule "ephem"]
 	path = feedstocks/ephem
 	url = https://github.com/conda-forge/ephem-feedstock.git
+	branch = refs/heads/master
 [submodule "jdatetime"]
 	path = feedstocks/jdatetime
 	url = https://github.com/conda-forge/jdatetime-feedstock.git
+	branch = refs/heads/master
 [submodule "mayavi"]
 	path = feedstocks/mayavi
 	url = https://github.com/conda-forge/mayavi-feedstock.git
+	branch = refs/heads/master
 [submodule "umalqurra"]
 	path = feedstocks/umalqurra
 	url = https://github.com/conda-forge/umalqurra-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-kbproto"]
 	path = feedstocks/xorg-kbproto
 	url = https://github.com/conda-forge/xorg-kbproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-recordproto"]
 	path = feedstocks/xorg-recordproto
 	url = https://github.com/conda-forge/xorg-recordproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-renderproto"]
 	path = feedstocks/xorg-renderproto
 	url = https://github.com/conda-forge/xorg-renderproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xextproto"]
 	path = feedstocks/xorg-xextproto
 	url = https://github.com/conda-forge/xorg-xextproto-feedstock.git
+	branch = refs/heads/master
 [submodule "appnope"]
 	path = feedstocks/appnope
 	url = https://github.com/conda-forge/appnope-feedstock.git
+	branch = refs/heads/master
 [submodule "cgsn-parsers"]
 	path = feedstocks/cgsn-parsers
 	url = https://github.com/conda-forge/cgsn-parsers-feedstock.git
+	branch = refs/heads/master
 [submodule "clangdev"]
 	path = feedstocks/clangdev
 	url = https://github.com/conda-forge/clangdev-feedstock.git
+	branch = refs/heads/master
 [submodule "dateparser"]
 	path = feedstocks/dateparser
 	url = https://github.com/conda-forge/dateparser-feedstock.git
+	branch = refs/heads/master
 [submodule "ghostscript"]
 	path = feedstocks/ghostscript
 	url = https://github.com/conda-forge/ghostscript-feedstock.git
+	branch = refs/heads/master
 [submodule "gmt"]
 	path = feedstocks/gmt
 	url = https://github.com/conda-forge/gmt-feedstock.git
+	branch = refs/heads/master
 [submodule "gobject-introspection"]
 	path = feedstocks/gobject-introspection
 	url = https://github.com/conda-forge/gobject-introspection-feedstock.git
+	branch = refs/heads/master
 [submodule "maya"]
 	path = feedstocks/maya
 	url = https://github.com/conda-forge/maya-feedstock.git
+	branch = refs/heads/master
 [submodule "pprintpp"]
 	path = feedstocks/pprintpp
 	url = https://github.com/conda-forge/pprintpp-feedstock.git
+	branch = refs/heads/master
 [submodule "pyabel"]
 	path = feedstocks/pyabel
 	url = https://github.com/conda-forge/pyabel-feedstock.git
+	branch = refs/heads/master
 [submodule "pymc"]
 	path = feedstocks/pymc
 	url = https://github.com/conda-forge/pymc-feedstock.git
+	branch = refs/heads/master
 [submodule "python-spake2"]
 	path = feedstocks/python-spake2
 	url = https://github.com/conda-forge/python-spake2-feedstock.git
+	branch = refs/heads/master
 [submodule "qcodes"]
 	path = feedstocks/qcodes
 	url = https://github.com/conda-forge/qcodes-feedstock.git
+	branch = refs/heads/master
 [submodule "rapidjson"]
 	path = feedstocks/rapidjson
 	url = https://github.com/conda-forge/rapidjson-feedstock.git
+	branch = refs/heads/master
 [submodule "testpath"]
 	path = feedstocks/testpath
 	url = https://github.com/conda-forge/testpath-feedstock.git
+	branch = refs/heads/master
 [submodule "wrf-python"]
 	path = feedstocks/wrf-python
 	url = https://github.com/conda-forge/wrf-python-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libpthread-stubs"]
 	path = feedstocks/xorg-libpthread-stubs
 	url = https://github.com/conda-forge/xorg-libpthread-stubs-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xcb-proto"]
 	path = feedstocks/xorg-xcb-proto
 	url = https://github.com/conda-forge/xorg-xcb-proto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xtrans"]
 	path = feedstocks/xorg-xtrans
 	url = https://github.com/conda-forge/xorg-xtrans-feedstock.git
+	branch = refs/heads/master
 [submodule "cryptopp"]
 	path = feedstocks/cryptopp
 	url = https://github.com/conda-forge/cryptopp-feedstock.git
+	branch = refs/heads/master
 [submodule "iolabs"]
 	path = feedstocks/iolabs
 	url = https://github.com/conda-forge/iolabs-feedstock.git
+	branch = refs/heads/master
 [submodule "ipopt"]
 	path = feedstocks/ipopt
 	url = https://github.com/conda-forge/ipopt-feedstock.git
+	branch = refs/heads/master
 [submodule "msgpack-c"]
 	path = feedstocks/msgpack-c
 	url = https://github.com/conda-forge/msgpack-c-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libx11"]
 	path = feedstocks/xorg-libx11
 	url = https://github.com/conda-forge/xorg-libx11-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxau"]
 	path = feedstocks/xorg-libxau
 	url = https://github.com/conda-forge/xorg-libxau-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxcb"]
 	path = feedstocks/xorg-libxcb
 	url = https://github.com/conda-forge/xorg-libxcb-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxdmcp"]
 	path = feedstocks/xorg-libxdmcp
 	url = https://github.com/conda-forge/xorg-libxdmcp-feedstock.git
+	branch = refs/heads/master
 [submodule "xsimd"]
 	path = feedstocks/xsimd
 	url = https://github.com/conda-forge/xsimd-feedstock.git
+	branch = refs/heads/master
 [submodule "cdat_info"]
 	path = feedstocks/cdat_info
 	url = https://github.com/conda-forge/cdat_info-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter"]
 	path = feedstocks/jupyter
 	url = https://github.com/conda-forge/jupyter-feedstock.git
+	branch = refs/heads/master
 [submodule "pyosf"]
 	path = feedstocks/pyosf
 	url = https://github.com/conda-forge/pyosf-feedstock.git
+	branch = refs/heads/master
 [submodule "aospy"]
 	path = feedstocks/aospy
 	url = https://github.com/conda-forge/aospy-feedstock.git
+	branch = refs/heads/master
 [submodule "cppzmq"]
 	path = feedstocks/cppzmq
 	url = https://github.com/conda-forge/cppzmq-feedstock.git
+	branch = refs/heads/master
 [submodule "funcy"]
 	path = feedstocks/funcy
 	url = https://github.com/conda-forge/funcy-feedstock.git
+	branch = refs/heads/master
 [submodule "libcxx"]
 	path = feedstocks/libcxx
 	url = https://github.com/conda-forge/libcxx-feedstock.git
+	branch = refs/heads/master
 [submodule "pefile"]
 	path = feedstocks/pefile
 	url = https://github.com/conda-forge/pefile-feedstock.git
+	branch = refs/heads/master
 [submodule "pgplot"]
 	path = feedstocks/pgplot
 	url = https://github.com/conda-forge/pgplot-feedstock.git
+	branch = refs/heads/master
 [submodule "pynacl"]
 	path = feedstocks/pynacl
 	url = https://github.com/conda-forge/pynacl-feedstock.git
+	branch = refs/heads/master
 [submodule "pywin32"]
 	path = feedstocks/pywin32
 	url = https://github.com/conda-forge/pywin32-feedstock.git
+	branch = refs/heads/master
 [submodule "reprounzip-docker"]
 	path = feedstocks/reprounzip-docker
 	url = https://github.com/conda-forge/reprounzip-docker-feedstock.git
+	branch = refs/heads/master
 [submodule "reprounzip"]
 	path = feedstocks/reprounzip
 	url = https://github.com/conda-forge/reprounzip-feedstock.git
+	branch = refs/heads/master
 [submodule "reprounzip-vagrant"]
 	path = feedstocks/reprounzip-vagrant
 	url = https://github.com/conda-forge/reprounzip-vagrant-feedstock.git
+	branch = refs/heads/master
 [submodule "reprozip"]
 	path = feedstocks/reprozip
 	url = https://github.com/conda-forge/reprozip-feedstock.git
+	branch = refs/heads/master
 [submodule "rpaths"]
 	path = feedstocks/rpaths
 	url = https://github.com/conda-forge/rpaths-feedstock.git
+	branch = refs/heads/master
 [submodule "spdlog"]
 	path = feedstocks/spdlog
 	url = https://github.com/conda-forge/spdlog-feedstock.git
+	branch = refs/heads/master
 [submodule "spyder-unittest"]
 	path = feedstocks/spyder-unittest
 	url = https://github.com/conda-forge/spyder-unittest-feedstock.git
+	branch = refs/heads/master
 [submodule "usagestats"]
 	path = feedstocks/usagestats
 	url = https://github.com/conda-forge/usagestats-feedstock.git
+	branch = refs/heads/master
 [submodule "webencodings"]
 	path = feedstocks/webencodings
 	url = https://github.com/conda-forge/webencodings-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libice"]
 	path = feedstocks/xorg-libice
 	url = https://github.com/conda-forge/xorg-libice-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libsm"]
 	path = feedstocks/xorg-libsm
 	url = https://github.com/conda-forge/xorg-libsm-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxext"]
 	path = feedstocks/xorg-libxext
 	url = https://github.com/conda-forge/xorg-libxext-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxfixes"]
 	path = feedstocks/xorg-libxfixes
 	url = https://github.com/conda-forge/xorg-libxfixes-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxi"]
 	path = feedstocks/xorg-libxi
 	url = https://github.com/conda-forge/xorg-libxi-feedstock.git
+	branch = refs/heads/master
 [submodule "cyipopt"]
 	path = feedstocks/cyipopt
 	url = https://github.com/conda-forge/cyipopt-feedstock.git
+	branch = refs/heads/master
 [submodule "make"]
 	path = feedstocks/make
 	url = https://github.com/conda-forge/make-feedstock.git
+	branch = refs/heads/master
 [submodule "version_information"]
 	path = feedstocks/version_information
 	url = https://github.com/conda-forge/version_information-feedstock.git
+	branch = refs/heads/master
 [submodule "dbfread"]
 	path = feedstocks/dbfread
 	url = https://github.com/conda-forge/dbfread-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-appbuilder"]
 	path = feedstocks/flask-appbuilder
 	url = https://github.com/conda-forge/flask-appbuilder-feedstock.git
+	branch = refs/heads/master
 [submodule "html5lib"]
 	path = feedstocks/html5lib
 	url = https://github.com/conda-forge/html5lib-feedstock.git
+	branch = refs/heads/master
 [submodule "ipympl"]
 	path = feedstocks/ipympl
 	url = https://github.com/conda-forge/ipympl-feedstock.git
+	branch = refs/heads/master
 [submodule "leather"]
 	path = feedstocks/leather
 	url = https://github.com/conda-forge/leather-feedstock.git
+	branch = refs/heads/master
 [submodule "mapkit"]
 	path = feedstocks/mapkit
 	url = https://github.com/conda-forge/mapkit-feedstock.git
+	branch = refs/heads/master
 [submodule "mshr"]
 	path = feedstocks/mshr
 	url = https://github.com/conda-forge/mshr-feedstock.git
+	branch = refs/heads/master
 [submodule "opty"]
 	path = feedstocks/opty
 	url = https://github.com/conda-forge/opty-feedstock.git
+	branch = refs/heads/master
 [submodule "proof"]
 	path = feedstocks/proof
 	url = https://github.com/conda-forge/proof-feedstock.git
+	branch = refs/heads/master
 [submodule "rapidpy"]
 	path = feedstocks/rapidpy
 	url = https://github.com/conda-forge/rapidpy-feedstock.git
+	branch = refs/heads/master
 [submodule "yeadon"]
 	path = feedstocks/yeadon
 	url = https://github.com/conda-forge/yeadon-feedstock.git
+	branch = refs/heads/master
 [submodule "argcomplete"]
 	path = feedstocks/argcomplete
 	url = https://github.com/conda-forge/argcomplete-feedstock.git
+	branch = refs/heads/master
 [submodule "chardet"]
 	path = feedstocks/chardet
 	url = https://github.com/conda-forge/chardet-feedstock.git
+	branch = refs/heads/master
 [submodule "cling-patches"]
 	path = feedstocks/cling-patches
 	url = https://github.com/conda-forge/cling-patches-feedstock.git
+	branch = refs/heads/master
 [submodule "craftr"]
 	path = feedstocks/craftr
 	url = https://github.com/conda-forge/craftr-feedstock.git
+	branch = refs/heads/master
 [submodule "flit"]
 	path = feedstocks/flit
 	url = https://github.com/conda-forge/flit-feedstock.git
+	branch = refs/heads/master
 [submodule "flit_install_py2"]
 	path = feedstocks/flit_install_py2
 	url = https://github.com/conda-forge/flit_install_py2-feedstock.git
+	branch = refs/heads/master
 [submodule "flufl.enum"]
 	path = feedstocks/flufl.enum
 	url = https://github.com/conda-forge/flufl.enum-feedstock.git
+	branch = refs/heads/master
 [submodule "geoplot"]
 	path = feedstocks/geoplot
 	url = https://github.com/conda-forge/geoplot-feedstock.git
+	branch = refs/heads/master
 [submodule "ipyvolume"]
 	path = feedstocks/ipyvolume
 	url = https://github.com/conda-forge/ipyvolume-feedstock.git
+	branch = refs/heads/master
 [submodule "latexcodec"]
 	path = feedstocks/latexcodec
 	url = https://github.com/conda-forge/latexcodec-feedstock.git
+	branch = refs/heads/master
 [submodule "pocl"]
 	path = feedstocks/pocl
 	url = https://github.com/conda-forge/pocl-feedstock.git
+	branch = refs/heads/master
 [submodule "pybinding"]
 	path = feedstocks/pybinding
 	url = https://github.com/conda-forge/pybinding-feedstock.git
+	branch = refs/heads/master
 [submodule "pylems"]
 	path = feedstocks/pylems
 	url = https://github.com/conda-forge/pylems-feedstock.git
+	branch = refs/heads/master
 [submodule "pytimeparse"]
 	path = feedstocks/pytimeparse
 	url = https://github.com/conda-forge/pytimeparse-feedstock.git
+	branch = refs/heads/master
 [submodule "requests_download"]
 	path = feedstocks/requests_download
 	url = https://github.com/conda-forge/requests_download-feedstock.git
+	branch = refs/heads/master
 [submodule "simhash"]
 	path = feedstocks/simhash
 	url = https://github.com/conda-forge/simhash-feedstock.git
+	branch = refs/heads/master
 [submodule "sixs"]
 	path = feedstocks/sixs
 	url = https://github.com/conda-forge/sixs-feedstock.git
+	branch = refs/heads/master
 [submodule "spylon-kernel"]
 	path = feedstocks/spylon-kernel
 	url = https://github.com/conda-forge/spylon-kernel-feedstock.git
+	branch = refs/heads/master
 [submodule "timezonefinder"]
 	path = feedstocks/timezonefinder
 	url = https://github.com/conda-forge/timezonefinder-feedstock.git
+	branch = refs/heads/master
 [submodule "validate_email"]
 	path = feedstocks/validate_email
 	url = https://github.com/conda-forge/validate_email-feedstock.git
+	branch = refs/heads/master
 [submodule "wikipedia"]
 	path = feedstocks/wikipedia
 	url = https://github.com/conda-forge/wikipedia-feedstock.git
+	branch = refs/heads/master
 [submodule "xeus"]
 	path = feedstocks/xeus
 	url = https://github.com/conda-forge/xeus-feedstock.git
+	branch = refs/heads/master
 [submodule "zipfile36"]
 	path = feedstocks/zipfile36
 	url = https://github.com/conda-forge/zipfile36-feedstock.git
+	branch = refs/heads/master
 [submodule "agate"]
 	path = feedstocks/agate
 	url = https://github.com/conda-forge/agate-feedstock.git
+	branch = refs/heads/master
 [submodule "clapack"]
 	path = feedstocks/clapack
 	url = https://github.com/conda-forge/clapack-feedstock.git
+	branch = refs/heads/master
 [submodule "distarray"]
 	path = feedstocks/distarray
 	url = https://github.com/conda-forge/distarray-feedstock.git
+	branch = refs/heads/master
 [submodule "esmp"]
 	path = feedstocks/esmp
 	url = https://github.com/conda-forge/esmp-feedstock.git
+	branch = refs/heads/master
 [submodule "luarocks"]
 	path = feedstocks/luarocks
 	url = https://github.com/conda-forge/luarocks-feedstock.git
+	branch = refs/heads/master
 [submodule "mpfi"]
 	path = feedstocks/mpfi
 	url = https://github.com/conda-forge/mpfi-feedstock.git
+	branch = refs/heads/master
 [submodule "ossuuid"]
 	path = feedstocks/ossuuid
 	url = https://github.com/conda-forge/ossuuid-feedstock.git
+	branch = refs/heads/master
 [submodule "pysolar"]
 	path = feedstocks/pysolar
 	url = https://github.com/conda-forge/pysolar-feedstock.git
+	branch = refs/heads/master
 [submodule "pysurfer"]
 	path = feedstocks/pysurfer
 	url = https://github.com/conda-forge/pysurfer-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxcursor"]
 	path = feedstocks/xorg-libxcursor
 	url = https://github.com/conda-forge/xorg-libxcursor-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxmu"]
 	path = feedstocks/xorg-libxmu
 	url = https://github.com/conda-forge/xorg-libxmu-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxpm"]
 	path = feedstocks/xorg-libxpm
 	url = https://github.com/conda-forge/xorg-libxpm-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxrender"]
 	path = feedstocks/xorg-libxrender
 	url = https://github.com/conda-forge/xorg-libxrender-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxt"]
 	path = feedstocks/xorg-libxt
 	url = https://github.com/conda-forge/xorg-libxt-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxtst"]
 	path = feedstocks/xorg-libxtst
 	url = https://github.com/conda-forge/xorg-libxtst-feedstock.git
+	branch = refs/heads/master
 [submodule "egal"]
 	path = feedstocks/egal
 	url = https://github.com/conda-forge/egal-feedstock.git
+	branch = refs/heads/master
 [submodule "fplll"]
 	path = feedstocks/fplll
 	url = https://github.com/conda-forge/fplll-feedstock.git
+	branch = refs/heads/master
 [submodule "gf2x"]
 	path = feedstocks/gf2x
 	url = https://github.com/conda-forge/gf2x-feedstock.git
+	branch = refs/heads/master
 [submodule "m4ri"]
 	path = feedstocks/m4ri
 	url = https://github.com/conda-forge/m4ri-feedstock.git
+	branch = refs/heads/master
 [submodule "m4rie"]
 	path = feedstocks/m4rie
 	url = https://github.com/conda-forge/m4rie-feedstock.git
+	branch = refs/heads/master
 [submodule "bcolz"]
 	path = feedstocks/bcolz
 	url = https://github.com/conda-forge/bcolz-feedstock.git
+	branch = refs/heads/master
 [submodule "agate-excel"]
 	path = feedstocks/agate-excel
 	url = https://github.com/conda-forge/agate-excel-feedstock.git
+	branch = refs/heads/master
 [submodule "brial"]
 	path = feedstocks/brial
 	url = https://github.com/conda-forge/brial-feedstock.git
+	branch = refs/heads/master
 [submodule "casadi"]
 	path = feedstocks/casadi
 	url = https://github.com/conda-forge/casadi-feedstock.git
+	branch = refs/heads/master
 [submodule "cddlib"]
 	path = feedstocks/cddlib
 	url = https://github.com/conda-forge/cddlib-feedstock.git
+	branch = refs/heads/master
 [submodule "celerite"]
 	path = feedstocks/celerite
 	url = https://github.com/conda-forge/celerite-feedstock.git
+	branch = refs/heads/master
 [submodule "chrpath"]
 	path = feedstocks/chrpath
 	url = https://github.com/conda-forge/chrpath-feedstock.git
+	branch = refs/heads/master
 [submodule "cliquer"]
 	path = feedstocks/cliquer
 	url = https://github.com/conda-forge/cliquer-feedstock.git
+	branch = refs/heads/master
 [submodule "courtana"]
 	path = feedstocks/courtana
 	url = https://github.com/conda-forge/courtana-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-apispec"]
 	path = feedstocks/flask-apispec
 	url = https://github.com/conda-forge/flask-apispec-feedstock.git
+	branch = refs/heads/master
 [submodule "gap"]
 	path = feedstocks/gap
 	url = https://github.com/conda-forge/gap-feedstock.git
+	branch = refs/heads/master
 [submodule "givaro"]
 	path = feedstocks/givaro
 	url = https://github.com/conda-forge/givaro-feedstock.git
+	branch = refs/heads/master
 [submodule "gsshapy"]
 	path = feedstocks/gsshapy
 	url = https://github.com/conda-forge/gsshapy-feedstock.git
+	branch = refs/heads/master
 [submodule "iml"]
 	path = feedstocks/iml
 	url = https://github.com/conda-forge/iml-feedstock.git
+	branch = refs/heads/master
 [submodule "libdrs"]
 	path = feedstocks/libdrs
 	url = https://github.com/conda-forge/libdrs-feedstock.git
+	branch = refs/heads/master
 [submodule "limix"]
 	path = feedstocks/limix
 	url = https://github.com/conda-forge/limix-feedstock.git
+	branch = refs/heads/master
 [submodule "lrcalc"]
 	path = feedstocks/lrcalc
 	url = https://github.com/conda-forge/lrcalc-feedstock.git
+	branch = refs/heads/master
 [submodule "ntl"]
 	path = feedstocks/ntl
 	url = https://github.com/conda-forge/ntl-feedstock.git
+	branch = refs/heads/master
 [submodule "pari"]
 	path = feedstocks/pari
 	url = https://github.com/conda-forge/pari-feedstock.git
+	branch = refs/heads/master
 [submodule "planarity"]
 	path = feedstocks/planarity
 	url = https://github.com/conda-forge/planarity-feedstock.git
+	branch = refs/heads/master
 [submodule "ppl"]
 	path = feedstocks/ppl
 	url = https://github.com/conda-forge/ppl-feedstock.git
+	branch = refs/heads/master
 [submodule "py-cpuinfo"]
 	path = feedstocks/py-cpuinfo
 	url = https://github.com/conda-forge/py-cpuinfo-feedstock.git
+	branch = refs/heads/master
 [submodule "py6s"]
 	path = feedstocks/py6s
 	url = https://github.com/conda-forge/py6s-feedstock.git
+	branch = refs/heads/master
 [submodule "python-stratify"]
 	path = feedstocks/python-stratify
 	url = https://github.com/conda-forge/python-stratify-feedstock.git
+	branch = refs/heads/master
 [submodule "pywps"]
 	path = feedstocks/pywps
 	url = https://github.com/conda-forge/pywps-feedstock.git
+	branch = refs/heads/master
 [submodule "ragel"]
 	path = feedstocks/ragel
 	url = https://github.com/conda-forge/ragel-feedstock.git
+	branch = refs/heads/master
 [submodule "ratpoints"]
 	path = feedstocks/ratpoints
 	url = https://github.com/conda-forge/ratpoints-feedstock.git
+	branch = refs/heads/master
 [submodule "simupop"]
 	path = feedstocks/simupop
 	url = https://github.com/conda-forge/simupop-feedstock.git
+	branch = refs/heads/master
 [submodule "superlu"]
 	path = feedstocks/superlu
 	url = https://github.com/conda-forge/superlu-feedstock.git
+	branch = refs/heads/master
 [submodule "symmetrica"]
 	path = feedstocks/symmetrica
 	url = https://github.com/conda-forge/symmetrica-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-cf-files"]
 	path = feedstocks/xorg-cf-files
 	url = https://github.com/conda-forge/xorg-cf-files-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-font-util"]
 	path = feedstocks/xorg-font-util
 	url = https://github.com/conda-forge/xorg-font-util-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-gccmakedep"]
 	path = feedstocks/xorg-gccmakedep
 	url = https://github.com/conda-forge/xorg-gccmakedep-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-imake"]
 	path = feedstocks/xorg-imake
 	url = https://github.com/conda-forge/xorg-imake-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxaw"]
 	path = feedstocks/xorg-libxaw
 	url = https://github.com/conda-forge/xorg-libxaw-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxaw3d"]
 	path = feedstocks/xorg-libxaw3d
 	url = https://github.com/conda-forge/xorg-libxaw3d-feedstock.git
+	branch = refs/heads/master
 [submodule "zn_poly"]
 	path = feedstocks/zn_poly
 	url = https://github.com/conda-forge/zn_poly-feedstock.git
+	branch = refs/heads/master
 [submodule "backports.lzma"]
 	path = feedstocks/backports.lzma
 	url = https://github.com/conda-forge/backports.lzma-feedstock.git
+	branch = refs/heads/master
 [submodule "colormap"]
 	path = feedstocks/colormap
 	url = https://github.com/conda-forge/colormap-feedstock.git
+	branch = refs/heads/master
 [submodule "easydev"]
 	path = feedstocks/easydev
 	url = https://github.com/conda-forge/easydev-feedstock.git
+	branch = refs/heads/master
 [submodule "ecl"]
 	path = feedstocks/ecl
 	url = https://github.com/conda-forge/ecl-feedstock.git
+	branch = refs/heads/master
 [submodule "eclib"]
 	path = feedstocks/eclib
 	url = https://github.com/conda-forge/eclib-feedstock.git
+	branch = refs/heads/master
 [submodule "fflas-ffpack"]
 	path = feedstocks/fflas-ffpack
 	url = https://github.com/conda-forge/fflas-ffpack-feedstock.git
+	branch = refs/heads/master
 [submodule "flintqs"]
 	path = feedstocks/flintqs
 	url = https://github.com/conda-forge/flintqs-feedstock.git
+	branch = refs/heads/master
 [submodule "gfan"]
 	path = feedstocks/gfan
 	url = https://github.com/conda-forge/gfan-feedstock.git
+	branch = refs/heads/master
 [submodule "lcalc"]
 	path = feedstocks/lcalc
 	url = https://github.com/conda-forge/lcalc-feedstock.git
+	branch = refs/heads/master
 [submodule "linbox"]
 	path = feedstocks/linbox
 	url = https://github.com/conda-forge/linbox-feedstock.git
+	branch = refs/heads/master
 [submodule "pynac"]
 	path = feedstocks/pynac
 	url = https://github.com/conda-forge/pynac-feedstock.git
+	branch = refs/heads/master
 [submodule "rw"]
 	path = feedstocks/rw
 	url = https://github.com/conda-forge/rw-feedstock.git
+	branch = refs/heads/master
 [submodule "sagemath-db-combinatorial-designs"]
 	path = feedstocks/sagemath-db-combinatorial-designs
 	url = https://github.com/conda-forge/sagemath-db-combinatorial-designs-feedstock.git
+	branch = refs/heads/master
 [submodule "sagemath-db-graphs"]
 	path = feedstocks/sagemath-db-graphs
 	url = https://github.com/conda-forge/sagemath-db-graphs-feedstock.git
+	branch = refs/heads/master
 [submodule "sagemath-db-polytopes"]
 	path = feedstocks/sagemath-db-polytopes
 	url = https://github.com/conda-forge/sagemath-db-polytopes-feedstock.git
+	branch = refs/heads/master
 [submodule "singular"]
 	path = feedstocks/singular
 	url = https://github.com/conda-forge/singular-feedstock.git
+	branch = refs/heads/master
 [submodule "homura"]
 	path = feedstocks/homura
 	url = https://github.com/conda-forge/homura-feedstock.git
+	branch = refs/heads/master
 [submodule "osx-pocl-opencl"]
 	path = feedstocks/osx-pocl-opencl
 	url = https://github.com/conda-forge/osx-pocl-opencl-feedstock.git
+	branch = refs/heads/master
 [submodule "polyline"]
 	path = feedstocks/polyline
 	url = https://github.com/conda-forge/polyline-feedstock.git
+	branch = refs/heads/master
 [submodule "ratelim"]
 	path = feedstocks/ratelim
 	url = https://github.com/conda-forge/ratelim-feedstock.git
+	branch = refs/heads/master
 [submodule "snzip"]
 	path = feedstocks/snzip
 	url = https://github.com/conda-forge/snzip-feedstock.git
+	branch = refs/heads/master
 [submodule "squash"]
 	path = feedstocks/squash
 	url = https://github.com/conda-forge/squash-feedstock.git
+	branch = refs/heads/master
 [submodule "doc8"]
 	path = feedstocks/doc8
 	url = https://github.com/conda-forge/doc8-feedstock.git
+	branch = refs/heads/master
 [submodule "geocoder"]
 	path = feedstocks/geocoder
 	url = https://github.com/conda-forge/geocoder-feedstock.git
+	branch = refs/heads/master
 [submodule "lmod"]
 	path = feedstocks/lmod
 	url = https://github.com/conda-forge/lmod-feedstock.git
+	branch = refs/heads/master
 [submodule "lua-luafilesystem"]
 	path = feedstocks/lua-luafilesystem
 	url = https://github.com/conda-forge/lua-luafilesystem-feedstock.git
+	branch = refs/heads/master
 [submodule "lua-luaposix"]
 	path = feedstocks/lua-luaposix
 	url = https://github.com/conda-forge/lua-luaposix-feedstock.git
+	branch = refs/heads/master
 [submodule "lzo"]
 	path = feedstocks/lzo
 	url = https://github.com/conda-forge/lzo-feedstock.git
+	branch = refs/heads/master
 [submodule "raven"]
 	path = feedstocks/raven
 	url = https://github.com/conda-forge/raven-feedstock.git
+	branch = refs/heads/master
 [submodule "restructuredtext_lint"]
 	path = feedstocks/restructuredtext_lint
 	url = https://github.com/conda-forge/restructuredtext_lint-feedstock.git
+	branch = refs/heads/master
 [submodule "usgs"]
 	path = feedstocks/usgs
 	url = https://github.com/conda-forge/usgs-feedstock.git
+	branch = refs/heads/master
 [submodule "agate-dbf"]
 	path = feedstocks/agate-dbf
 	url = https://github.com/conda-forge/agate-dbf-feedstock.git
+	branch = refs/heads/master
 [submodule "easybuild-easyblocks"]
 	path = feedstocks/easybuild-easyblocks
 	url = https://github.com/conda-forge/easybuild-easyblocks-feedstock.git
+	branch = refs/heads/master
 [submodule "easybuild-easyconfigs"]
 	path = feedstocks/easybuild-easyconfigs
 	url = https://github.com/conda-forge/easybuild-easyconfigs-feedstock.git
+	branch = refs/heads/master
 [submodule "easybuild"]
 	path = feedstocks/easybuild
 	url = https://github.com/conda-forge/easybuild-feedstock.git
+	branch = refs/heads/master
 [submodule "easybuild-framework"]
 	path = feedstocks/easybuild-framework
 	url = https://github.com/conda-forge/easybuild-framework-feedstock.git
+	branch = refs/heads/master
 [submodule "environment-modules"]
 	path = feedstocks/environment-modules
 	url = https://github.com/conda-forge/environment-modules-feedstock.git
+	branch = refs/heads/master
 [submodule "pymagej"]
 	path = feedstocks/pymagej
 	url = https://github.com/conda-forge/pymagej-feedstock.git
+	branch = refs/heads/master
 [submodule "r-boot"]
 	path = feedstocks/r-boot
 	url = https://github.com/conda-forge/r-boot-feedstock.git
+	branch = refs/heads/master
 [submodule "vsc-base"]
 	path = feedstocks/vsc-base
 	url = https://github.com/conda-forge/vsc-base-feedstock.git
+	branch = refs/heads/master
 [submodule "vsc-install"]
 	path = feedstocks/vsc-install
 	url = https://github.com/conda-forge/vsc-install-feedstock.git
+	branch = refs/heads/master
 [submodule "agate-lookup"]
 	path = feedstocks/agate-lookup
 	url = https://github.com/conda-forge/agate-lookup-feedstock.git
+	branch = refs/heads/master
 [submodule "agate-remote"]
 	path = feedstocks/agate-remote
 	url = https://github.com/conda-forge/agate-remote-feedstock.git
+	branch = refs/heads/master
 [submodule "agate-sql"]
 	path = feedstocks/agate-sql
 	url = https://github.com/conda-forge/agate-sql-feedstock.git
+	branch = refs/heads/master
 [submodule "agate-stats"]
 	path = feedstocks/agate-stats
 	url = https://github.com/conda-forge/agate-stats-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter-dashboards-server"]
 	path = feedstocks/jupyter-dashboards-server
 	url = https://github.com/conda-forge/jupyter-dashboards-server-feedstock.git
+	branch = refs/heads/master
 [submodule "mesalib"]
 	path = feedstocks/mesalib
 	url = https://github.com/conda-forge/mesalib-feedstock.git
+	branch = refs/heads/master
 [submodule "r-crayon"]
 	path = feedstocks/r-crayon
 	url = https://github.com/conda-forge/r-crayon-feedstock.git
+	branch = refs/heads/master
 [submodule "r-digest"]
 	path = feedstocks/r-digest
 	url = https://github.com/conda-forge/r-digest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gsw"]
 	path = feedstocks/r-gsw
 	url = https://github.com/conda-forge/r-gsw-feedstock.git
+	branch = refs/heads/master
 [submodule "r-jsonlite"]
 	path = feedstocks/r-jsonlite
 	url = https://github.com/conda-forge/r-jsonlite-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lattice"]
 	path = feedstocks/r-lattice
 	url = https://github.com/conda-forge/r-lattice-feedstock.git
+	branch = refs/heads/master
 [submodule "r-magrittr"]
 	path = feedstocks/r-magrittr
 	url = https://github.com/conda-forge/r-magrittr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r6"]
 	path = feedstocks/r-r6
 	url = https://github.com/conda-forge/r-r6-feedstock.git
+	branch = refs/heads/master
 [submodule "r-repr"]
 	path = feedstocks/r-repr
 	url = https://github.com/conda-forge/r-repr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-stringi"]
 	path = feedstocks/r-stringi
 	url = https://github.com/conda-forge/r-stringi-feedstock.git
+	branch = refs/heads/master
 [submodule "r-uuid"]
 	path = feedstocks/r-uuid
 	url = https://github.com/conda-forge/r-uuid-feedstock.git
+	branch = refs/heads/master
 [submodule "cymem"]
 	path = feedstocks/cymem
 	url = https://github.com/conda-forge/cymem-feedstock.git
+	branch = refs/heads/master
 [submodule "libcdms"]
 	path = feedstocks/libcdms
 	url = https://github.com/conda-forge/libcdms-feedstock.git
+	branch = refs/heads/master
 [submodule "libcf"]
 	path = feedstocks/libcf
 	url = https://github.com/conda-forge/libcf-feedstock.git
+	branch = refs/heads/master
 [submodule "libdrs_f"]
 	path = feedstocks/libdrs_f
 	url = https://github.com/conda-forge/libdrs_f-feedstock.git
+	branch = refs/heads/master
 [submodule "murmurhash"]
 	path = feedstocks/murmurhash
 	url = https://github.com/conda-forge/murmurhash-feedstock.git
+	branch = refs/heads/master
 [submodule "preshed"]
 	path = feedstocks/preshed
 	url = https://github.com/conda-forge/preshed-feedstock.git
+	branch = refs/heads/master
 [submodule "r-evaluate"]
 	path = feedstocks/r-evaluate
 	url = https://github.com/conda-forge/r-evaluate-feedstock.git
+	branch = refs/heads/master
 [submodule "r-irdisplay"]
 	path = feedstocks/r-irdisplay
 	url = https://github.com/conda-forge/r-irdisplay-feedstock.git
+	branch = refs/heads/master
 [submodule "r-irkernel"]
 	path = feedstocks/r-irkernel
 	url = https://github.com/conda-forge/r-irkernel-feedstock.git
+	branch = refs/heads/master
 [submodule "r-matrix"]
 	path = feedstocks/r-matrix
 	url = https://github.com/conda-forge/r-matrix-feedstock.git
+	branch = refs/heads/master
 [submodule "r-oce"]
 	path = feedstocks/r-oce
 	url = https://github.com/conda-forge/r-oce-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pbdzmq"]
 	path = feedstocks/r-pbdzmq
 	url = https://github.com/conda-forge/r-pbdzmq-feedstock.git
+	branch = refs/heads/master
 [submodule "r-stringr"]
 	path = feedstocks/r-stringr
 	url = https://github.com/conda-forge/r-stringr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-survival"]
 	path = feedstocks/r-survival
 	url = https://github.com/conda-forge/r-survival-feedstock.git
+	branch = refs/heads/master
 [submodule "semver"]
 	path = feedstocks/semver
 	url = https://github.com/conda-forge/semver-feedstock.git
+	branch = refs/heads/master
 [submodule "spacy"]
 	path = feedstocks/spacy
 	url = https://github.com/conda-forge/spacy-feedstock.git
+	branch = refs/heads/master
 [submodule "sputnik"]
 	path = feedstocks/sputnik
 	url = https://github.com/conda-forge/sputnik-feedstock.git
+	branch = refs/heads/master
 [submodule "thinc"]
 	path = feedstocks/thinc
 	url = https://github.com/conda-forge/thinc-feedstock.git
+	branch = refs/heads/master
 [submodule "yajl"]
 	path = feedstocks/yajl
 	url = https://github.com/conda-forge/yajl-feedstock.git
+	branch = refs/heads/master
 [submodule "cdtime"]
 	path = feedstocks/cdtime
 	url = https://github.com/conda-forge/cdtime-feedstock.git
+	branch = refs/heads/master
 [submodule "cling"]
 	path = feedstocks/cling
 	url = https://github.com/conda-forge/cling-feedstock.git
+	branch = refs/heads/master
 [submodule "kernda"]
 	path = feedstocks/kernda
 	url = https://github.com/conda-forge/kernda-feedstock.git
+	branch = refs/heads/master
 [submodule "orange3-network"]
 	path = feedstocks/orange3-network
 	url = https://github.com/conda-forge/orange3-network-feedstock.git
+	branch = refs/heads/master
 [submodule "orange3-timeseries"]
 	path = feedstocks/orange3-timeseries
 	url = https://github.com/conda-forge/orange3-timeseries-feedstock.git
+	branch = refs/heads/master
 [submodule "py-lz4framed"]
 	path = feedstocks/py-lz4framed
 	url = https://github.com/conda-forge/py-lz4framed-feedstock.git
+	branch = refs/heads/master
 [submodule "beautifulsoup4"]
 	path = feedstocks/beautifulsoup4
 	url = https://github.com/conda-forge/beautifulsoup4-feedstock.git
+	branch = refs/heads/master
 [submodule "casacore"]
 	path = feedstocks/casacore
 	url = https://github.com/conda-forge/casacore-feedstock.git
+	branch = refs/heads/master
 [submodule "mne"]
 	path = feedstocks/mne
 	url = https://github.com/conda-forge/mne-feedstock.git
+	branch = refs/heads/master
 [submodule "lz4-c"]
 	path = feedstocks/lz4-c
 	url = https://github.com/conda-forge/lz4-c-feedstock.git
+	branch = refs/heads/master
 [submodule "pysolr"]
 	path = feedstocks/pysolr
 	url = https://github.com/conda-forge/pysolr-feedstock.git
+	branch = refs/heads/master
 [submodule "tweepy"]
 	path = feedstocks/tweepy
 	url = https://github.com/conda-forge/tweepy-feedstock.git
+	branch = refs/heads/master
 [submodule "libgap"]
 	path = feedstocks/libgap
 	url = https://github.com/conda-forge/libgap-feedstock.git
+	branch = refs/heads/master
 [submodule "sagemath-db-elliptic-curves"]
 	path = feedstocks/sagemath-db-elliptic-curves
 	url = https://github.com/conda-forge/sagemath-db-elliptic-curves-feedstock.git
+	branch = refs/heads/master
 [submodule "vine"]
 	path = feedstocks/vine
 	url = https://github.com/conda-forge/vine-feedstock.git
+	branch = refs/heads/master
 [submodule "reports"]
 	path = feedstocks/reports
 	url = https://github.com/conda-forge/reports-feedstock.git
+	branch = refs/heads/master
 [submodule "bzip2"]
 	path = feedstocks/bzip2
 	url = https://github.com/conda-forge/bzip2-feedstock.git
+	branch = refs/heads/master
 [submodule "ldaptor"]
 	path = feedstocks/ldaptor
 	url = https://github.com/conda-forge/ldaptor-feedstock.git
+	branch = refs/heads/master
 [submodule "libsakura"]
 	path = feedstocks/libsakura
 	url = https://github.com/conda-forge/libsakura-feedstock.git
+	branch = refs/heads/master
 [submodule "attrs"]
 	path = feedstocks/attrs
 	url = https://github.com/conda-forge/attrs-feedstock.git
+	branch = refs/heads/master
 [submodule "dectate"]
 	path = feedstocks/dectate
 	url = https://github.com/conda-forge/dectate-feedstock.git
+	branch = refs/heads/master
 [submodule "easytest"]
 	path = feedstocks/easytest
 	url = https://github.com/conda-forge/easytest-feedstock.git
+	branch = refs/heads/master
 [submodule "graphite2"]
 	path = feedstocks/graphite2
 	url = https://github.com/conda-forge/graphite2-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_sphinx"]
 	path = feedstocks/jupyter_sphinx
 	url = https://github.com/conda-forge/jupyter_sphinx-feedstock.git
+	branch = refs/heads/master
 [submodule "parse"]
 	path = feedstocks/parse
 	url = https://github.com/conda-forge/parse-feedstock.git
+	branch = refs/heads/master
 [submodule "pytoml"]
 	path = feedstocks/pytoml
 	url = https://github.com/conda-forge/pytoml-feedstock.git
+	branch = refs/heads/master
 [submodule "sagelib"]
 	path = feedstocks/sagelib
 	url = https://github.com/conda-forge/sagelib-feedstock.git
+	branch = refs/heads/master
 [submodule "argon2_cffi"]
 	path = feedstocks/argon2_cffi
 	url = https://github.com/conda-forge/argon2_cffi-feedstock.git
+	branch = refs/heads/master
 [submodule "bowerstatic"]
 	path = feedstocks/bowerstatic
 	url = https://github.com/conda-forge/bowerstatic-feedstock.git
+	branch = refs/heads/master
 [submodule "cached-property"]
 	path = feedstocks/cached-property
 	url = https://github.com/conda-forge/cached-property-feedstock.git
+	branch = refs/heads/master
 [submodule "fpylll"]
 	path = feedstocks/fpylll
 	url = https://github.com/conda-forge/fpylll-feedstock.git
+	branch = refs/heads/master
 [submodule "orange3-text"]
 	path = feedstocks/orange3-text
 	url = https://github.com/conda-forge/orange3-text-feedstock.git
+	branch = refs/heads/master
 [submodule "otfmi"]
 	path = feedstocks/otfmi
 	url = https://github.com/conda-forge/otfmi-feedstock.git
+	branch = refs/heads/master
 [submodule "publish"]
 	path = feedstocks/publish
 	url = https://github.com/conda-forge/publish-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxjp.themes.impressjs"]
 	path = feedstocks/sphinxjp.themes.impressjs
 	url = https://github.com/conda-forge/sphinxjp.themes.impressjs-feedstock.git
+	branch = refs/heads/master
 [submodule "unixodbc"]
 	path = feedstocks/unixodbc
 	url = https://github.com/conda-forge/unixodbc-feedstock.git
+	branch = refs/heads/master
 [submodule "webob"]
 	path = feedstocks/webob
 	url = https://github.com/conda-forge/webob-feedstock.git
+	branch = refs/heads/master
 [submodule "rubiks"]
 	path = feedstocks/rubiks
 	url = https://github.com/conda-forge/rubiks-feedstock.git
+	branch = refs/heads/master
 [submodule "bibtexparser"]
 	path = feedstocks/bibtexparser
 	url = https://github.com/conda-forge/bibtexparser-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-mirror"]
 	path = feedstocks/conda-mirror
 	url = https://github.com/conda-forge/conda-mirror-feedstock.git
+	branch = refs/heads/master
 [submodule "crochet"]
 	path = feedstocks/crochet
 	url = https://github.com/conda-forge/crochet-feedstock.git
+	branch = refs/heads/master
 [submodule "icalendar"]
 	path = feedstocks/icalendar
 	url = https://github.com/conda-forge/icalendar-feedstock.git
+	branch = refs/heads/master
 [submodule "nauty"]
 	path = feedstocks/nauty
 	url = https://github.com/conda-forge/nauty-feedstock.git
+	branch = refs/heads/master
 [submodule "palp"]
 	path = feedstocks/palp
 	url = https://github.com/conda-forge/palp-feedstock.git
+	branch = refs/heads/master
 [submodule "polib"]
 	path = feedstocks/polib
 	url = https://github.com/conda-forge/polib-feedstock.git
+	branch = refs/heads/master
 [submodule "python-constraint"]
 	path = feedstocks/python-constraint
 	url = https://github.com/conda-forge/python-constraint-feedstock.git
+	branch = refs/heads/master
 [submodule "sagemath-db-conway-polynomials"]
 	path = feedstocks/sagemath-db-conway-polynomials
 	url = https://github.com/conda-forge/sagemath-db-conway-polynomials-feedstock.git
+	branch = refs/heads/master
 [submodule "scipy-sugar"]
 	path = feedstocks/scipy-sugar
 	url = https://github.com/conda-forge/scipy-sugar-feedstock.git
+	branch = refs/heads/master
 [submodule "armadillo"]
 	path = feedstocks/armadillo
 	url = https://github.com/conda-forge/armadillo-feedstock.git
+	branch = refs/heads/master
 [submodule "cppunit"]
 	path = feedstocks/cppunit
 	url = https://github.com/conda-forge/cppunit-feedstock.git
+	branch = refs/heads/master
 [submodule "giac"]
 	path = feedstocks/giac
 	url = https://github.com/conda-forge/giac-feedstock.git
+	branch = refs/heads/master
 [submodule "importscan"]
 	path = feedstocks/importscan
 	url = https://github.com/conda-forge/importscan-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-gbq"]
 	path = feedstocks/pandas-gbq
 	url = https://github.com/conda-forge/pandas-gbq-feedstock.git
+	branch = refs/heads/master
 [submodule "poppler-data"]
 	path = feedstocks/poppler-data
 	url = https://github.com/conda-forge/poppler-data-feedstock.git
+	branch = refs/heads/master
 [submodule "poppler"]
 	path = feedstocks/poppler
 	url = https://github.com/conda-forge/poppler-feedstock.git
+	branch = refs/heads/master
 [submodule "pynamical"]
 	path = feedstocks/pynamical
 	url = https://github.com/conda-forge/pynamical-feedstock.git
+	branch = refs/heads/master
 [submodule "pyseaweed"]
 	path = feedstocks/pyseaweed
 	url = https://github.com/conda-forge/pyseaweed-feedstock.git
+	branch = refs/heads/master
 [submodule "reg"]
 	path = feedstocks/reg
 	url = https://github.com/conda-forge/reg-feedstock.git
+	branch = refs/heads/master
 [submodule "xlrd"]
 	path = feedstocks/xlrd
 	url = https://github.com/conda-forge/xlrd-feedstock.git
+	branch = refs/heads/master
 [submodule "beaker"]
 	path = feedstocks/beaker
 	url = https://github.com/conda-forge/beaker-feedstock.git
+	branch = refs/heads/master
 [submodule "ddt"]
 	path = feedstocks/ddt
 	url = https://github.com/conda-forge/ddt-feedstock.git
+	branch = refs/heads/master
 [submodule "mockredispy"]
 	path = feedstocks/mockredispy
 	url = https://github.com/conda-forge/mockredispy-feedstock.git
+	branch = refs/heads/master
 [submodule "morepath"]
 	path = feedstocks/morepath
 	url = https://github.com/conda-forge/morepath-feedstock.git
+	branch = refs/heads/master
 [submodule "parse_type"]
 	path = feedstocks/parse_type
 	url = https://github.com/conda-forge/parse_type-feedstock.git
+	branch = refs/heads/master
 [submodule "pyscss"]
 	path = feedstocks/pyscss
 	url = https://github.com/conda-forge/pyscss-feedstock.git
+	branch = refs/heads/master
 [submodule "pystan"]
 	path = feedstocks/pystan
 	url = https://github.com/conda-forge/pystan-feedstock.git
+	branch = refs/heads/master
 [submodule "virtualenv"]
 	path = feedstocks/virtualenv
 	url = https://github.com/conda-forge/virtualenv-feedstock.git
+	branch = refs/heads/master
 [submodule "nglview"]
 	path = feedstocks/nglview
 	url = https://github.com/conda-forge/nglview-feedstock.git
+	branch = refs/heads/master
 [submodule "colour-science"]
 	path = feedstocks/colour-science
 	url = https://github.com/conda-forge/colour-science-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-verify"]
 	path = feedstocks/conda-verify
 	url = https://github.com/conda-forge/conda-verify-feedstock.git
+	branch = refs/heads/master
 [submodule "more.forwarded"]
 	path = feedstocks/more.forwarded
 	url = https://github.com/conda-forge/more.forwarded-feedstock.git
+	branch = refs/heads/master
 [submodule "more.pathtool"]
 	path = feedstocks/more.pathtool
 	url = https://github.com/conda-forge/more.pathtool-feedstock.git
+	branch = refs/heads/master
 [submodule "more.static"]
 	path = feedstocks/more.static
 	url = https://github.com/conda-forge/more.static-feedstock.git
+	branch = refs/heads/master
 [submodule "betfairlightweight"]
 	path = feedstocks/betfairlightweight
 	url = https://github.com/conda-forge/betfairlightweight-feedstock.git
+	branch = refs/heads/master
 [submodule "docrep"]
 	path = feedstocks/docrep
 	url = https://github.com/conda-forge/docrep-feedstock.git
+	branch = refs/heads/master
 [submodule "geomalgo"]
 	path = feedstocks/geomalgo
 	url = https://github.com/conda-forge/geomalgo-feedstock.git
+	branch = refs/heads/master
 [submodule "goftests"]
 	path = feedstocks/goftests
 	url = https://github.com/conda-forge/goftests-feedstock.git
+	branch = refs/heads/master
 [submodule "halide"]
 	path = feedstocks/halide
 	url = https://github.com/conda-forge/halide-feedstock.git
+	branch = refs/heads/master
 [submodule "pyasdf"]
 	path = feedstocks/pyasdf
 	url = https://github.com/conda-forge/pyasdf-feedstock.git
+	branch = refs/heads/master
 [submodule "pyxid"]
 	path = feedstocks/pyxid
 	url = https://github.com/conda-forge/pyxid-feedstock.git
+	branch = refs/heads/master
 [submodule "statistics"]
 	path = feedstocks/statistics
 	url = https://github.com/conda-forge/statistics-feedstock.git
+	branch = refs/heads/master
 [submodule "zeep"]
 	path = feedstocks/zeep
 	url = https://github.com/conda-forge/zeep-feedstock.git
+	branch = refs/heads/master
 [submodule "openfst"]
 	path = feedstocks/openfst
 	url = https://github.com/conda-forge/openfst-feedstock.git
+	branch = refs/heads/master
 [submodule "behave"]
 	path = feedstocks/behave
 	url = https://github.com/conda-forge/behave-feedstock.git
+	branch = refs/heads/master
 [submodule "cdms2"]
 	path = feedstocks/cdms2
 	url = https://github.com/conda-forge/cdms2-feedstock.git
+	branch = refs/heads/master
 [submodule "natsort"]
 	path = feedstocks/natsort
 	url = https://github.com/conda-forge/natsort-feedstock.git
+	branch = refs/heads/master
 [submodule "pypeg2"]
 	path = feedstocks/pypeg2
 	url = https://github.com/conda-forge/pypeg2-feedstock.git
+	branch = refs/heads/master
 [submodule "python-fmask"]
 	path = feedstocks/python-fmask
 	url = https://github.com/conda-forge/python-fmask-feedstock.git
+	branch = refs/heads/master
 [submodule "sensorml2iso"]
 	path = feedstocks/sensorml2iso
 	url = https://github.com/conda-forge/sensorml2iso-feedstock.git
+	branch = refs/heads/master
 [submodule "speex"]
 	path = feedstocks/speex
 	url = https://github.com/conda-forge/speex-feedstock.git
+	branch = refs/heads/master
 [submodule "maven"]
 	path = feedstocks/maven
 	url = https://github.com/conda-forge/maven-feedstock.git
+	branch = refs/heads/master
 [submodule "rdflib"]
 	path = feedstocks/rdflib
 	url = https://github.com/conda-forge/rdflib-feedstock.git
+	branch = refs/heads/master
 [submodule "bumpversion"]
 	path = feedstocks/bumpversion
 	url = https://github.com/conda-forge/bumpversion-feedstock.git
+	branch = refs/heads/master
 [submodule "csvkit"]
 	path = feedstocks/csvkit
 	url = https://github.com/conda-forge/csvkit-feedstock.git
+	branch = refs/heads/master
 [submodule "rply"]
 	path = feedstocks/rply
 	url = https://github.com/conda-forge/rply-feedstock.git
+	branch = refs/heads/master
 [submodule "sympow"]
 	path = feedstocks/sympow
 	url = https://github.com/conda-forge/sympow-feedstock.git
+	branch = refs/heads/master
 [submodule "aubio"]
 	path = feedstocks/aubio
 	url = https://github.com/conda-forge/aubio-feedstock.git
+	branch = refs/heads/master
 [submodule "cheroot"]
 	path = feedstocks/cheroot
 	url = https://github.com/conda-forge/cheroot-feedstock.git
+	branch = refs/heads/master
 [submodule "glue-core"]
 	path = feedstocks/glue-core
 	url = https://github.com/conda-forge/glue-core-feedstock.git
+	branch = refs/heads/master
 [submodule "maxima"]
 	path = feedstocks/maxima
 	url = https://github.com/conda-forge/maxima-feedstock.git
+	branch = refs/heads/master
 [submodule "python-memcached"]
 	path = feedstocks/python-memcached
 	url = https://github.com/conda-forge/python-memcached-feedstock.git
+	branch = refs/heads/master
 [submodule "tikzmagic"]
 	path = feedstocks/tikzmagic
 	url = https://github.com/conda-forge/tikzmagic-feedstock.git
+	branch = refs/heads/master
 [submodule "pycifrw"]
 	path = feedstocks/pycifrw
 	url = https://github.com/conda-forge/pycifrw-feedstock.git
+	branch = refs/heads/master
 [submodule "pyspark"]
 	path = feedstocks/pyspark
 	url = https://github.com/conda-forge/pyspark-feedstock.git
+	branch = refs/heads/master
 [submodule "sage"]
 	path = feedstocks/sage
 	url = https://github.com/conda-forge/sage-feedstock.git
+	branch = refs/heads/master
 [submodule "urlobject"]
 	path = feedstocks/urlobject
 	url = https://github.com/conda-forge/urlobject-feedstock.git
+	branch = refs/heads/master
 [submodule "win_inet_pton"]
 	path = feedstocks/win_inet_pton
 	url = https://github.com/conda-forge/win_inet_pton-feedstock.git
+	branch = refs/heads/master
 [submodule "interpolation"]
 	path = feedstocks/interpolation
 	url = https://github.com/conda-forge/interpolation-feedstock.git
+	branch = refs/heads/master
 [submodule "xgboost"]
 	path = feedstocks/xgboost
 	url = https://github.com/conda-forge/xgboost-feedstock.git
+	branch = refs/heads/master
 [submodule "faker"]
 	path = feedstocks/faker
 	url = https://github.com/conda-forge/faker-feedstock.git
+	branch = refs/heads/master
 [submodule "geographiclib"]
 	path = feedstocks/geographiclib
 	url = https://github.com/conda-forge/geographiclib-feedstock.git
+	branch = refs/heads/master
 [submodule "pdir2"]
 	path = feedstocks/pdir2
 	url = https://github.com/conda-forge/pdir2-feedstock.git
+	branch = refs/heads/master
 [submodule "flaky"]
 	path = feedstocks/flaky
 	url = https://github.com/conda-forge/flaky-feedstock.git
+	branch = refs/heads/master
 [submodule "mr.bob"]
 	path = feedstocks/mr.bob
 	url = https://github.com/conda-forge/mr.bob-feedstock.git
+	branch = refs/heads/master
 [submodule "mysql-connector-python"]
 	path = feedstocks/mysql-connector-python
 	url = https://github.com/conda-forge/mysql-connector-python-feedstock.git
+	branch = refs/heads/master
 [submodule "sqlalchemy-migrate"]
 	path = feedstocks/sqlalchemy-migrate
 	url = https://github.com/conda-forge/sqlalchemy-migrate-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-devenv"]
 	path = feedstocks/conda-devenv
 	url = https://github.com/conda-forge/conda-devenv-feedstock.git
+	branch = refs/heads/master
 [submodule "kafkacat"]
 	path = feedstocks/kafkacat
 	url = https://github.com/conda-forge/kafkacat-feedstock.git
+	branch = refs/heads/master
 [submodule "pychef"]
 	path = feedstocks/pychef
 	url = https://github.com/conda-forge/pychef-feedstock.git
+	branch = refs/heads/master
 [submodule "pyslet"]
 	path = feedstocks/pyslet
 	url = https://github.com/conda-forge/pyslet-feedstock.git
+	branch = refs/heads/master
 [submodule "python-confluent-kafka"]
 	path = feedstocks/python-confluent-kafka
 	url = https://github.com/conda-forge/python-confluent-kafka-feedstock.git
+	branch = refs/heads/master
 [submodule "routes"]
 	path = feedstocks/routes
 	url = https://github.com/conda-forge/routes-feedstock.git
+	branch = refs/heads/master
 [submodule "scons"]
 	path = feedstocks/scons
 	url = https://github.com/conda-forge/scons-feedstock.git
+	branch = refs/heads/master
 [submodule "simhash-py"]
 	path = feedstocks/simhash-py
 	url = https://github.com/conda-forge/simhash-py-feedstock.git
+	branch = refs/heads/master
 [submodule "tempora"]
 	path = feedstocks/tempora
 	url = https://github.com/conda-forge/tempora-feedstock.git
+	branch = refs/heads/master
 [submodule "pympler"]
 	path = feedstocks/pympler
 	url = https://github.com/conda-forge/pympler-feedstock.git
+	branch = refs/heads/master
 [submodule "datacube"]
 	path = feedstocks/datacube
 	url = https://github.com/conda-forge/datacube-feedstock.git
+	branch = refs/heads/master
 [submodule "libgpuarray"]
 	path = feedstocks/libgpuarray
 	url = https://github.com/conda-forge/libgpuarray-feedstock.git
+	branch = refs/heads/master
 [submodule "py-ubjson"]
 	path = feedstocks/py-ubjson
 	url = https://github.com/conda-forge/py-ubjson-feedstock.git
+	branch = refs/heads/master
 [submodule "ctk-cli"]
 	path = feedstocks/ctk-cli
 	url = https://github.com/conda-forge/ctk-cli-feedstock.git
+	branch = refs/heads/master
 [submodule "larray"]
 	path = feedstocks/larray
 	url = https://github.com/conda-forge/larray-feedstock.git
+	branch = refs/heads/master
 [submodule "r-class"]
 	path = feedstocks/r-class
 	url = https://github.com/conda-forge/r-class-feedstock.git
+	branch = refs/heads/master
 [submodule "r-cluster"]
 	path = feedstocks/r-cluster
 	url = https://github.com/conda-forge/r-cluster-feedstock.git
+	branch = refs/heads/master
 [submodule "r-codetools"]
 	path = feedstocks/r-codetools
 	url = https://github.com/conda-forge/r-codetools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-foreign"]
 	path = feedstocks/r-foreign
 	url = https://github.com/conda-forge/r-foreign-feedstock.git
+	branch = refs/heads/master
 [submodule "r-kernsmooth"]
 	path = feedstocks/r-kernsmooth
 	url = https://github.com/conda-forge/r-kernsmooth-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mass"]
 	path = feedstocks/r-mass
 	url = https://github.com/conda-forge/r-mass-feedstock.git
+	branch = refs/heads/master
 [submodule "textadapter"]
 	path = feedstocks/textadapter
 	url = https://github.com/conda-forge/textadapter-feedstock.git
+	branch = refs/heads/master
 [submodule "utfcpp"]
 	path = feedstocks/utfcpp
 	url = https://github.com/conda-forge/utfcpp-feedstock.git
+	branch = refs/heads/master
 [submodule "f90nml"]
 	path = feedstocks/f90nml
 	url = https://github.com/conda-forge/f90nml-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mgcv"]
 	path = feedstocks/r-mgcv
 	url = https://github.com/conda-forge/r-mgcv-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nlme"]
 	path = feedstocks/r-nlme
 	url = https://github.com/conda-forge/r-nlme-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nnet"]
 	path = feedstocks/r-nnet
 	url = https://github.com/conda-forge/r-nnet-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rpart"]
 	path = feedstocks/r-rpart
 	url = https://github.com/conda-forge/r-rpart-feedstock.git
+	branch = refs/heads/master
 [submodule "r-spatial"]
 	path = feedstocks/r-spatial
 	url = https://github.com/conda-forge/r-spatial-feedstock.git
+	branch = refs/heads/master
 [submodule "spyder-line-profiler"]
 	path = feedstocks/spyder-line-profiler
 	url = https://github.com/conda-forge/spyder-line-profiler-feedstock.git
+	branch = refs/heads/master
 [submodule "dxfgrabber"]
 	path = feedstocks/dxfgrabber
 	url = https://github.com/conda-forge/dxfgrabber-feedstock.git
+	branch = refs/heads/master
 [submodule "george"]
 	path = feedstocks/george
 	url = https://github.com/conda-forge/george-feedstock.git
+	branch = refs/heads/master
 [submodule "spyder-memory-profiler"]
 	path = feedstocks/spyder-memory-profiler
 	url = https://github.com/conda-forge/spyder-memory-profiler-feedstock.git
+	branch = refs/heads/master
 [submodule "tblib"]
 	path = feedstocks/tblib
 	url = https://github.com/conda-forge/tblib-feedstock.git
+	branch = refs/heads/master
 [submodule "zstd"]
 	path = feedstocks/zstd
 	url = https://github.com/conda-forge/zstd-feedstock.git
+	branch = refs/heads/master
 [submodule "argtable2"]
 	path = feedstocks/argtable2
 	url = https://github.com/conda-forge/argtable2-feedstock.git
+	branch = refs/heads/master
 [submodule "astor"]
 	path = feedstocks/astor
 	url = https://github.com/conda-forge/astor-feedstock.git
+	branch = refs/heads/master
 [submodule "jira"]
 	path = feedstocks/jira
 	url = https://github.com/conda-forge/jira-feedstock.git
+	branch = refs/heads/master
 [submodule "openpyxl"]
 	path = feedstocks/openpyxl
 	url = https://github.com/conda-forge/openpyxl-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-msgpack"]
 	path = feedstocks/pandas-msgpack
 	url = https://github.com/conda-forge/pandas-msgpack-feedstock.git
+	branch = refs/heads/master
 [submodule "portend"]
 	path = feedstocks/portend
 	url = https://github.com/conda-forge/portend-feedstock.git
+	branch = refs/heads/master
 [submodule "pycandela"]
 	path = feedstocks/pycandela
 	url = https://github.com/conda-forge/pycandela-feedstock.git
+	branch = refs/heads/master
 [submodule "python-json-logger"]
 	path = feedstocks/python-json-logger
 	url = https://github.com/conda-forge/python-json-logger-feedstock.git
+	branch = refs/heads/master
 [submodule "rope"]
 	path = feedstocks/rope
 	url = https://github.com/conda-forge/rope-feedstock.git
+	branch = refs/heads/master
 [submodule "smartypants"]
 	path = feedstocks/smartypants
 	url = https://github.com/conda-forge/smartypants-feedstock.git
+	branch = refs/heads/master
 [submodule "socat"]
 	path = feedstocks/socat
 	url = https://github.com/conda-forge/socat-feedstock.git
+	branch = refs/heads/master
 [submodule "splunk_handler"]
 	path = feedstocks/splunk_handler
 	url = https://github.com/conda-forge/splunk_handler-feedstock.git
+	branch = refs/heads/master
 [submodule "tempdir"]
 	path = feedstocks/tempdir
 	url = https://github.com/conda-forge/tempdir-feedstock.git
+	branch = refs/heads/master
 [submodule "libev"]
 	path = feedstocks/libev
 	url = https://github.com/conda-forge/libev-feedstock.git
+	branch = refs/heads/master
 [submodule "libsndfile"]
 	path = feedstocks/libsndfile
 	url = https://github.com/conda-forge/libsndfile-feedstock.git
+	branch = refs/heads/master
 [submodule "liknorm-py"]
 	path = feedstocks/liknorm-py
 	url = https://github.com/conda-forge/liknorm-py-feedstock.git
+	branch = refs/heads/master
 [submodule "pescador"]
 	path = feedstocks/pescador
 	url = https://github.com/conda-forge/pescador-feedstock.git
+	branch = refs/heads/master
 [submodule "rednose"]
 	path = feedstocks/rednose
 	url = https://github.com/conda-forge/rednose-feedstock.git
+	branch = refs/heads/master
 [submodule "scalapack"]
 	path = feedstocks/scalapack
 	url = https://github.com/conda-forge/scalapack-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxft"]
 	path = feedstocks/xorg-libxft
 	url = https://github.com/conda-forge/xorg-libxft-feedstock.git
+	branch = refs/heads/master
 [submodule "typogrify"]
 	path = feedstocks/typogrify
 	url = https://github.com/conda-forge/typogrify-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-xgboost"]
 	path = feedstocks/dask-xgboost
 	url = https://github.com/conda-forge/dask-xgboost-feedstock.git
+	branch = refs/heads/master
 [submodule "fig2dev"]
 	path = feedstocks/fig2dev
 	url = https://github.com/conda-forge/fig2dev-feedstock.git
+	branch = refs/heads/master
 [submodule "freediscovery"]
 	path = feedstocks/freediscovery
 	url = https://github.com/conda-forge/freediscovery-feedstock.git
+	branch = refs/heads/master
 [submodule "libmagic"]
 	path = feedstocks/libmagic
 	url = https://github.com/conda-forge/libmagic-feedstock.git
+	branch = refs/heads/master
 [submodule "mdanalysis"]
 	path = feedstocks/mdanalysis
 	url = https://github.com/conda-forge/mdanalysis-feedstock.git
+	branch = refs/heads/master
 [submodule "mpg123"]
 	path = feedstocks/mpg123
 	url = https://github.com/conda-forge/mpg123-feedstock.git
+	branch = refs/heads/master
 [submodule "msmbuilder"]
 	path = feedstocks/msmbuilder
 	url = https://github.com/conda-forge/msmbuilder-feedstock.git
+	branch = refs/heads/master
 [submodule "mu_repo"]
 	path = feedstocks/mu_repo
 	url = https://github.com/conda-forge/mu_repo-feedstock.git
+	branch = refs/heads/master
 [submodule "mwclient"]
 	path = feedstocks/mwclient
 	url = https://github.com/conda-forge/mwclient-feedstock.git
+	branch = refs/heads/master
 [submodule "pocean-core"]
 	path = feedstocks/pocean-core
 	url = https://github.com/conda-forge/pocean-core-feedstock.git
+	branch = refs/heads/master
 [submodule "promise"]
 	path = feedstocks/promise
 	url = https://github.com/conda-forge/promise-feedstock.git
+	branch = refs/heads/master
 [submodule "python-magic"]
 	path = feedstocks/python-magic
 	url = https://github.com/conda-forge/python-magic-feedstock.git
+	branch = refs/heads/master
 [submodule "weave"]
 	path = feedstocks/weave
 	url = https://github.com/conda-forge/weave-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-searchcv"]
 	path = feedstocks/dask-searchcv
 	url = https://github.com/conda-forge/dask-searchcv-feedstock.git
+	branch = refs/heads/master
 [submodule "elektronn"]
 	path = feedstocks/elektronn
 	url = https://github.com/conda-forge/elektronn-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-ldap3-login"]
 	path = feedstocks/flask-ldap3-login
 	url = https://github.com/conda-forge/flask-ldap3-login-feedstock.git
+	branch = refs/heads/master
 [submodule "inflect"]
 	path = feedstocks/inflect
 	url = https://github.com/conda-forge/inflect-feedstock.git
+	branch = refs/heads/master
 [submodule "markovify"]
 	path = feedstocks/markovify
 	url = https://github.com/conda-forge/markovify-feedstock.git
+	branch = refs/heads/master
 [submodule "mastodon.py"]
 	path = feedstocks/mastodon.py
 	url = https://github.com/conda-forge/mastodon.py-feedstock.git
+	branch = refs/heads/master
 [submodule "mdsynthesis"]
 	path = feedstocks/mdsynthesis
 	url = https://github.com/conda-forge/mdsynthesis-feedstock.git
+	branch = refs/heads/master
 [submodule "pocket"]
 	path = feedstocks/pocket
 	url = https://github.com/conda-forge/pocket-feedstock.git
+	branch = refs/heads/master
 [submodule "pyhmc"]
 	path = feedstocks/pyhmc
 	url = https://github.com/conda-forge/pyhmc-feedstock.git
+	branch = refs/heads/master
 [submodule "rotamerconvolvemd"]
 	path = feedstocks/rotamerconvolvemd
 	url = https://github.com/conda-forge/rotamerconvolvemd-feedstock.git
+	branch = refs/heads/master
 [submodule "sciluigi"]
 	path = feedstocks/sciluigi
 	url = https://github.com/conda-forge/sciluigi-feedstock.git
+	branch = refs/heads/master
 [submodule "turbodbc"]
 	path = feedstocks/turbodbc
 	url = https://github.com/conda-forge/turbodbc-feedstock.git
+	branch = refs/heads/master
 [submodule "waybackpack"]
 	path = feedstocks/waybackpack
 	url = https://github.com/conda-forge/waybackpack-feedstock.git
+	branch = refs/heads/master
 [submodule "bokeh"]
 	path = feedstocks/bokeh
 	url = https://github.com/conda-forge/bokeh-feedstock.git
+	branch = refs/heads/master
 [submodule "cassandra-driver"]
 	path = feedstocks/cassandra-driver
 	url = https://github.com/conda-forge/cassandra-driver-feedstock.git
+	branch = refs/heads/master
 [submodule "kaldi"]
 	path = feedstocks/kaldi
 	url = https://github.com/conda-forge/kaldi-feedstock.git
+	branch = refs/heads/master
 [submodule "modernize"]
 	path = feedstocks/modernize
 	url = https://github.com/conda-forge/modernize-feedstock.git
+	branch = refs/heads/master
 [submodule "more-itertools"]
 	path = feedstocks/more-itertools
 	url = https://github.com/conda-forge/more-itertools-feedstock.git
+	branch = refs/heads/master
 [submodule "pure-sasl"]
 	path = feedstocks/pure-sasl
 	url = https://github.com/conda-forge/pure-sasl-feedstock.git
+	branch = refs/heads/master
 [submodule "xfig"]
 	path = feedstocks/xfig
 	url = https://github.com/conda-forge/xfig-feedstock.git
+	branch = refs/heads/master
 [submodule "yaafe"]
 	path = feedstocks/yaafe
 	url = https://github.com/conda-forge/yaafe-feedstock.git
+	branch = refs/heads/master
 [submodule "climlab"]
 	path = feedstocks/climlab
 	url = https://github.com/conda-forge/climlab-feedstock.git
+	branch = refs/heads/master
 [submodule "jieba"]
 	path = feedstocks/jieba
 	url = https://github.com/conda-forge/jieba-feedstock.git
+	branch = refs/heads/master
 [submodule "utm"]
 	path = feedstocks/utm
 	url = https://github.com/conda-forge/utm-feedstock.git
+	branch = refs/heads/master
 [submodule "weightedcalcs"]
 	path = feedstocks/weightedcalcs
 	url = https://github.com/conda-forge/weightedcalcs-feedstock.git
+	branch = refs/heads/master
 [submodule "jaraco.classes"]
 	path = feedstocks/jaraco.classes
 	url = https://github.com/conda-forge/jaraco.classes-feedstock.git
+	branch = refs/heads/master
 [submodule "mdanalysistests"]
 	path = feedstocks/mdanalysistests
 	url = https://github.com/conda-forge/mdanalysistests-feedstock.git
+	branch = refs/heads/master
 [submodule "orcid"]
 	path = feedstocks/orcid
 	url = https://github.com/conda-forge/orcid-feedstock.git
+	branch = refs/heads/master
 [submodule "pstdint"]
 	path = feedstocks/pstdint
 	url = https://github.com/conda-forge/pstdint-feedstock.git
+	branch = refs/heads/master
 [submodule "r-acepack"]
 	path = feedstocks/r-acepack
 	url = https://github.com/conda-forge/r-acepack-feedstock.git
+	branch = refs/heads/master
 [submodule "r-adgoftest"]
 	path = feedstocks/r-adgoftest
 	url = https://github.com/conda-forge/r-adgoftest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-base64enc"]
 	path = feedstocks/r-base64enc
 	url = https://github.com/conda-forge/r-base64enc-feedstock.git
+	branch = refs/heads/master
 [submodule "gspread"]
 	path = feedstocks/gspread
 	url = https://github.com/conda-forge/gspread-feedstock.git
+	branch = refs/heads/master
 [submodule "jaraco.logging"]
 	path = feedstocks/jaraco.logging
 	url = https://github.com/conda-forge/jaraco.logging-feedstock.git
+	branch = refs/heads/master
 [submodule "nbval"]
 	path = feedstocks/nbval
 	url = https://github.com/conda-forge/nbval-feedstock.git
+	branch = refs/heads/master
 [submodule "pygeobase"]
 	path = feedstocks/pygeobase
 	url = https://github.com/conda-forge/pygeobase-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bdsmatrix"]
 	path = feedstocks/r-bdsmatrix
 	url = https://github.com/conda-forge/r-bdsmatrix-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bh"]
 	path = feedstocks/r-bh
 	url = https://github.com/conda-forge/r-bh-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bit"]
 	path = feedstocks/r-bit
 	url = https://github.com/conda-forge/r-bit-feedstock.git
+	branch = refs/heads/master
 [submodule "habanero"]
 	path = feedstocks/habanero
 	url = https://github.com/conda-forge/habanero-feedstock.git
+	branch = refs/heads/master
 [submodule "r-highr"]
 	path = feedstocks/r-highr
 	url = https://github.com/conda-forge/r-highr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hms"]
 	path = feedstocks/r-hms
 	url = https://github.com/conda-forge/r-hms-feedstock.git
+	branch = refs/heads/master
 [submodule "schwimmbad"]
 	path = feedstocks/schwimmbad
 	url = https://github.com/conda-forge/schwimmbad-feedstock.git
+	branch = refs/heads/master
 [submodule "ads"]
 	path = feedstocks/ads
 	url = https://github.com/conda-forge/ads-feedstock.git
+	branch = refs/heads/master
 [submodule "metaphone"]
 	path = feedstocks/metaphone
 	url = https://github.com/conda-forge/metaphone-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dichromat"]
 	path = feedstocks/r-dichromat
 	url = https://github.com/conda-forge/r-dichromat-feedstock.git
+	branch = refs/heads/master
 [submodule "astroquery"]
 	path = feedstocks/astroquery
 	url = https://github.com/conda-forge/astroquery-feedstock.git
+	branch = refs/heads/master
 [submodule "chest"]
 	path = feedstocks/chest
 	url = https://github.com/conda-forge/chest-feedstock.git
+	branch = refs/heads/master
 [submodule "corner"]
 	path = feedstocks/corner
 	url = https://github.com/conda-forge/corner-feedstock.git
+	branch = refs/heads/master
 [submodule "dropbox"]
 	path = feedstocks/dropbox
 	url = https://github.com/conda-forge/dropbox-feedstock.git
+	branch = refs/heads/master
 [submodule "fbprophet"]
 	path = feedstocks/fbprophet
 	url = https://github.com/conda-forge/fbprophet-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-security"]
 	path = feedstocks/flask-security
 	url = https://github.com/conda-forge/flask-security-feedstock.git
+	branch = refs/heads/master
 [submodule "genutil"]
 	path = feedstocks/genutil
 	url = https://github.com/conda-forge/genutil-feedstock.git
+	branch = refs/heads/master
 [submodule "hypre"]
 	path = feedstocks/hypre
 	url = https://github.com/conda-forge/hypre-feedstock.git
+	branch = refs/heads/master
 [submodule "jaraco.stream"]
 	path = feedstocks/jaraco.stream
 	url = https://github.com/conda-forge/jaraco.stream-feedstock.git
+	branch = refs/heads/master
 [submodule "jdcal"]
 	path = feedstocks/jdcal
 	url = https://github.com/conda-forge/jdcal-feedstock.git
+	branch = refs/heads/master
 [submodule "molpx"]
 	path = feedstocks/molpx
 	url = https://github.com/conda-forge/molpx-feedstock.git
+	branch = refs/heads/master
 [submodule "nd2reader"]
 	path = feedstocks/nd2reader
 	url = https://github.com/conda-forge/nd2reader-feedstock.git
+	branch = refs/heads/master
 [submodule "pluggy"]
 	path = feedstocks/pluggy
 	url = https://github.com/conda-forge/pluggy-feedstock.git
+	branch = refs/heads/master
 [submodule "r-assertthat"]
 	path = feedstocks/r-assertthat
 	url = https://github.com/conda-forge/r-assertthat-feedstock.git
+	branch = refs/heads/master
 [submodule "r-backports"]
 	path = feedstocks/r-backports
 	url = https://github.com/conda-forge/r-backports-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bitops"]
 	path = feedstocks/r-bitops
 	url = https://github.com/conda-forge/r-bitops-feedstock.git
+	branch = refs/heads/master
 [submodule "r-brew"]
 	path = feedstocks/r-brew
 	url = https://github.com/conda-forge/r-brew-feedstock.git
+	branch = refs/heads/master
 [submodule "r-chron"]
 	path = feedstocks/r-chron
 	url = https://github.com/conda-forge/r-chron-feedstock.git
+	branch = refs/heads/master
 [submodule "r-colorspace"]
 	path = feedstocks/r-colorspace
 	url = https://github.com/conda-forge/r-colorspace-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ctv"]
 	path = feedstocks/r-ctv
 	url = https://github.com/conda-forge/r-ctv-feedstock.git
+	branch = refs/heads/master
 [submodule "r-curl"]
 	path = feedstocks/r-curl
 	url = https://github.com/conda-forge/r-curl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-data.table"]
 	path = feedstocks/r-data.table
 	url = https://github.com/conda-forge/r-data.table-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dbi"]
 	path = feedstocks/r-dbi
 	url = https://github.com/conda-forge/r-dbi-feedstock.git
+	branch = refs/heads/master
 [submodule "r-deoptimr"]
 	path = feedstocks/r-deoptimr
 	url = https://github.com/conda-forge/r-deoptimr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-estimability"]
 	path = feedstocks/r-estimability
 	url = https://github.com/conda-forge/r-estimability-feedstock.git
+	branch = refs/heads/master
 [submodule "r-formatr"]
 	path = feedstocks/r-formatr
 	url = https://github.com/conda-forge/r-formatr-feedstock.git
+	branch = refs/heads/master
 [submodule "marray"]
 	path = feedstocks/marray
 	url = https://github.com/conda-forge/marray-feedstock.git
+	branch = refs/heads/master
 [submodule "pydstool"]
 	path = feedstocks/pydstool
 	url = https://github.com/conda-forge/pydstool-feedstock.git
+	branch = refs/heads/master
 [submodule "r-formula"]
 	path = feedstocks/r-formula
 	url = https://github.com/conda-forge/r-formula-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fracdiff"]
 	path = feedstocks/r-fracdiff
 	url = https://github.com/conda-forge/r-fracdiff-feedstock.git
+	branch = refs/heads/master
 [submodule "r-functional"]
 	path = feedstocks/r-functional
 	url = https://github.com/conda-forge/r-functional-feedstock.git
+	branch = refs/heads/master
 [submodule "r-git2r"]
 	path = feedstocks/r-git2r
 	url = https://github.com/conda-forge/r-git2r-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gridbase"]
 	path = feedstocks/r-gridbase
 	url = https://github.com/conda-forge/r-gridbase-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gsl"]
 	path = feedstocks/r-gsl
 	url = https://github.com/conda-forge/r-gsl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gtable"]
 	path = feedstocks/r-gtable
 	url = https://github.com/conda-forge/r-gtable-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gtools"]
 	path = feedstocks/r-gtools
 	url = https://github.com/conda-forge/r-gtools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-iterators"]
 	path = feedstocks/r-iterators
 	url = https://github.com/conda-forge/r-iterators-feedstock.git
+	branch = refs/heads/master
 [submodule "r-janeaustenr"]
 	path = feedstocks/r-janeaustenr
 	url = https://github.com/conda-forge/r-janeaustenr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-jpeg"]
 	path = feedstocks/r-jpeg
 	url = https://github.com/conda-forge/r-jpeg-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx-autobuild"]
 	path = feedstocks/sphinx-autobuild
 	url = https://github.com/conda-forge/sphinx-autobuild-feedstock.git
+	branch = refs/heads/master
 [submodule "thrift_sasl"]
 	path = feedstocks/thrift_sasl
 	url = https://github.com/conda-forge/thrift_sasl-feedstock.git
+	branch = refs/heads/master
 [submodule "df2gspread"]
 	path = feedstocks/df2gspread
 	url = https://github.com/conda-forge/df2gspread-feedstock.git
+	branch = refs/heads/master
 [submodule "pagmo"]
 	path = feedstocks/pagmo
 	url = https://github.com/conda-forge/pagmo-feedstock.git
+	branch = refs/heads/master
 [submodule "pycairo"]
 	path = feedstocks/pycairo
 	url = https://github.com/conda-forge/pycairo-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-makedepend"]
 	path = feedstocks/xorg-makedepend
 	url = https://github.com/conda-forge/xorg-makedepend-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-printproto"]
 	path = feedstocks/xorg-printproto
 	url = https://github.com/conda-forge/xorg-printproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xbitmaps"]
 	path = feedstocks/xorg-xbitmaps
 	url = https://github.com/conda-forge/xorg-xbitmaps-feedstock.git
+	branch = refs/heads/master
 [submodule "astrocats"]
 	path = feedstocks/astrocats
 	url = https://github.com/conda-forge/astrocats-feedstock.git
+	branch = refs/heads/master
 [submodule "atomicwrites"]
 	path = feedstocks/atomicwrites
 	url = https://github.com/conda-forge/atomicwrites-feedstock.git
+	branch = refs/heads/master
 [submodule "param"]
 	path = feedstocks/param
 	url = https://github.com/conda-forge/param-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-lazy-fixture"]
 	path = feedstocks/pytest-lazy-fixture
 	url = https://github.com/conda-forge/pytest-lazy-fixture-feedstock.git
+	branch = refs/heads/master
 [submodule "delegator"]
 	path = feedstocks/delegator
 	url = https://github.com/conda-forge/delegator-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-datareader"]
 	path = feedstocks/pandas-datareader
 	url = https://github.com/conda-forge/pandas-datareader-feedstock.git
+	branch = refs/heads/master
 [submodule "requests-ftp"]
 	path = feedstocks/requests-ftp
 	url = https://github.com/conda-forge/requests-ftp-feedstock.git
+	branch = refs/heads/master
 [submodule "toposort"]
 	path = feedstocks/toposort
 	url = https://github.com/conda-forge/toposort-feedstock.git
+	branch = refs/heads/master
 [submodule "codecov"]
 	path = feedstocks/codecov
 	url = https://github.com/conda-forge/codecov-feedstock.git
+	branch = refs/heads/master
 [submodule "r"]
 	path = feedstocks/r
 	url = https://github.com/conda-forge/r-feedstock.git
+	branch = refs/heads/master
 [submodule "r-labeling"]
 	path = feedstocks/r-labeling
 	url = https://github.com/conda-forge/r-labeling-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lars"]
 	path = feedstocks/r-lars
 	url = https://github.com/conda-forge/r-lars-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lazyeval"]
 	path = feedstocks/r-lazyeval
 	url = https://github.com/conda-forge/r-lazyeval-feedstock.git
+	branch = refs/heads/master
 [submodule "r-leaps"]
 	path = feedstocks/r-leaps
 	url = https://github.com/conda-forge/r-leaps-feedstock.git
+	branch = refs/heads/master
 [submodule "r-logging"]
 	path = feedstocks/r-logging
 	url = https://github.com/conda-forge/r-logging-feedstock.git
+	branch = refs/heads/master
 [submodule "r-manipulate"]
 	path = feedstocks/r-manipulate
 	url = https://github.com/conda-forge/r-manipulate-feedstock.git
+	branch = refs/heads/master
 [submodule "r-maps"]
 	path = feedstocks/r-maps
 	url = https://github.com/conda-forge/r-maps-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mime"]
 	path = feedstocks/r-mime
 	url = https://github.com/conda-forge/r-mime-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mnormt"]
 	path = feedstocks/r-mnormt
 	url = https://github.com/conda-forge/r-mnormt-feedstock.git
+	branch = refs/heads/master
 [submodule "r-modeltools"]
 	path = feedstocks/r-modeltools
 	url = https://github.com/conda-forge/r-modeltools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mvtnorm"]
 	path = feedstocks/r-mvtnorm
 	url = https://github.com/conda-forge/r-mvtnorm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nloptr"]
 	path = feedstocks/r-nloptr
 	url = https://github.com/conda-forge/r-nloptr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nlp"]
 	path = feedstocks/r-nlp
 	url = https://github.com/conda-forge/r-nlp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-numderiv"]
 	path = feedstocks/r-numderiv
 	url = https://github.com/conda-forge/r-numderiv-feedstock.git
+	branch = refs/heads/master
 [submodule "r-recommended"]
 	path = feedstocks/r-recommended
 	url = https://github.com/conda-forge/r-recommended-feedstock.git
+	branch = refs/heads/master
 [submodule "hy"]
 	path = feedstocks/hy
 	url = https://github.com/conda-forge/hy-feedstock.git
+	branch = refs/heads/master
 [submodule "libsemigroups"]
 	path = feedstocks/libsemigroups
 	url = https://github.com/conda-forge/libsemigroups-feedstock.git
+	branch = refs/heads/master
 [submodule "nginx"]
 	path = feedstocks/nginx
 	url = https://github.com/conda-forge/nginx-feedstock.git
+	branch = refs/heads/master
 [submodule "requests-unixsocket"]
 	path = feedstocks/requests-unixsocket
 	url = https://github.com/conda-forge/requests-unixsocket-feedstock.git
+	branch = refs/heads/master
 [submodule "scijava-jupyter-kernel"]
 	path = feedstocks/scijava-jupyter-kernel
 	url = https://github.com/conda-forge/scijava-jupyter-kernel-feedstock.git
+	branch = refs/heads/master
 [submodule "vault"]
 	path = feedstocks/vault
 	url = https://github.com/conda-forge/vault-feedstock.git
+	branch = refs/heads/master
 [submodule "libsemigroups-python-bindings"]
 	path = feedstocks/libsemigroups-python-bindings
 	url = https://github.com/conda-forge/libsemigroups-python-bindings-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-applewmproto"]
 	path = feedstocks/xorg-applewmproto
 	url = https://github.com/conda-forge/xorg-applewmproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-bigreqsproto"]
 	path = feedstocks/xorg-bigreqsproto
 	url = https://github.com/conda-forge/xorg-bigreqsproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-compositeproto"]
 	path = feedstocks/xorg-compositeproto
 	url = https://github.com/conda-forge/xorg-compositeproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-damageproto"]
 	path = feedstocks/xorg-damageproto
 	url = https://github.com/conda-forge/xorg-damageproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-dmxproto"]
 	path = feedstocks/xorg-dmxproto
 	url = https://github.com/conda-forge/xorg-dmxproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-evieext"]
 	path = feedstocks/xorg-evieext
 	url = https://github.com/conda-forge/xorg-evieext-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-fontcacheproto"]
 	path = feedstocks/xorg-fontcacheproto
 	url = https://github.com/conda-forge/xorg-fontcacheproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-fontsproto"]
 	path = feedstocks/xorg-fontsproto
 	url = https://github.com/conda-forge/xorg-fontsproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-glproto"]
 	path = feedstocks/xorg-glproto
 	url = https://github.com/conda-forge/xorg-glproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-presentproto"]
 	path = feedstocks/xorg-presentproto
 	url = https://github.com/conda-forge/xorg-presentproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-randrproto"]
 	path = feedstocks/xorg-randrproto
 	url = https://github.com/conda-forge/xorg-randrproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-resourceproto"]
 	path = feedstocks/xorg-resourceproto
 	url = https://github.com/conda-forge/xorg-resourceproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-scrnsaverproto"]
 	path = feedstocks/xorg-scrnsaverproto
 	url = https://github.com/conda-forge/xorg-scrnsaverproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-trapproto"]
 	path = feedstocks/xorg-trapproto
 	url = https://github.com/conda-forge/xorg-trapproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-videoproto"]
 	path = feedstocks/xorg-videoproto
 	url = https://github.com/conda-forge/xorg-videoproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-windowswmproto"]
 	path = feedstocks/xorg-windowswmproto
 	url = https://github.com/conda-forge/xorg-windowswmproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xcmiscproto"]
 	path = feedstocks/xorg-xcmiscproto
 	url = https://github.com/conda-forge/xorg-xcmiscproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xf86bigfontproto"]
 	path = feedstocks/xorg-xf86bigfontproto
 	url = https://github.com/conda-forge/xorg-xf86bigfontproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xf86dgaproto"]
 	path = feedstocks/xorg-xf86dgaproto
 	url = https://github.com/conda-forge/xorg-xf86dgaproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xf86driproto"]
 	path = feedstocks/xorg-xf86driproto
 	url = https://github.com/conda-forge/xorg-xf86driproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xf86miscproto"]
 	path = feedstocks/xorg-xf86miscproto
 	url = https://github.com/conda-forge/xorg-xf86miscproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xf86rushproto"]
 	path = feedstocks/xorg-xf86rushproto
 	url = https://github.com/conda-forge/xorg-xf86rushproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xf86vidmodeproto"]
 	path = feedstocks/xorg-xf86vidmodeproto
 	url = https://github.com/conda-forge/xorg-xf86vidmodeproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xineramaproto"]
 	path = feedstocks/xorg-xineramaproto
 	url = https://github.com/conda-forge/xorg-xineramaproto-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-xproxymanagementprotocol"]
 	path = feedstocks/xorg-xproxymanagementprotocol
 	url = https://github.com/conda-forge/xorg-xproxymanagementprotocol-feedstock.git
+	branch = refs/heads/master
 [submodule "consul"]
 	path = feedstocks/consul
 	url = https://github.com/conda-forge/consul-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter-themer"]
 	path = feedstocks/jupyter-themer
 	url = https://github.com/conda-forge/jupyter-themer-feedstock.git
+	branch = refs/heads/master
 [submodule "terraform"]
 	path = feedstocks/terraform
 	url = https://github.com/conda-forge/terraform-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxp"]
 	path = feedstocks/xorg-libxp
 	url = https://github.com/conda-forge/xorg-libxp-feedstock.git
+	branch = refs/heads/master
 [submodule "consul-template"]
 	path = feedstocks/consul-template
 	url = https://github.com/conda-forge/consul-template-feedstock.git
+	branch = refs/heads/master
 [submodule "ftfy"]
 	path = feedstocks/ftfy
 	url = https://github.com/conda-forge/ftfy-feedstock.git
+	branch = refs/heads/master
 [submodule "mosfit"]
 	path = feedstocks/mosfit
 	url = https://github.com/conda-forge/mosfit-feedstock.git
+	branch = refs/heads/master
 [submodule "r-cairo"]
 	path = feedstocks/r-cairo
 	url = https://github.com/conda-forge/r-cairo-feedstock.git
+	branch = refs/heads/master
 [submodule "r-findpython"]
 	path = feedstocks/r-findpython
 	url = https://github.com/conda-forge/r-findpython-feedstock.git
+	branch = refs/heads/master
 [submodule "r-getopt"]
 	path = feedstocks/r-getopt
 	url = https://github.com/conda-forge/r-getopt-feedstock.git
+	branch = refs/heads/master
 [submodule "r-inline"]
 	path = feedstocks/r-inline
 	url = https://github.com/conda-forge/r-inline-feedstock.git
+	branch = refs/heads/master
 [submodule "r-packrat"]
 	path = feedstocks/r-packrat
 	url = https://github.com/conda-forge/r-packrat-feedstock.git
+	branch = refs/heads/master
 [submodule "r-perm"]
 	path = feedstocks/r-perm
 	url = https://github.com/conda-forge/r-perm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-plogr"]
 	path = feedstocks/r-plogr
 	url = https://github.com/conda-forge/r-plogr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-png"]
 	path = feedstocks/r-png
 	url = https://github.com/conda-forge/r-png-feedstock.git
+	branch = refs/heads/master
 [submodule "r-praise"]
 	path = feedstocks/r-praise
 	url = https://github.com/conda-forge/r-praise-feedstock.git
+	branch = refs/heads/master
 [submodule "r-profilemodel"]
 	path = feedstocks/r-profilemodel
 	url = https://github.com/conda-forge/r-profilemodel-feedstock.git
+	branch = refs/heads/master
 [submodule "r-proto"]
 	path = feedstocks/r-proto
 	url = https://github.com/conda-forge/r-proto-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pspline"]
 	path = feedstocks/r-pspline
 	url = https://github.com/conda-forge/r-pspline-feedstock.git
+	branch = refs/heads/master
 [submodule "r-quadprog"]
 	path = feedstocks/r-quadprog
 	url = https://github.com/conda-forge/r-quadprog-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.methodss3"]
 	path = feedstocks/r-r.methodss3
 	url = https://github.com/conda-forge/r-r.methodss3-feedstock.git
+	branch = refs/heads/master
 [submodule "r-randomforest"]
 	path = feedstocks/r-randomforest
 	url = https://github.com/conda-forge/r-randomforest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rappdirs"]
 	path = feedstocks/r-rappdirs
 	url = https://github.com/conda-forge/r-rappdirs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcolorbrewer"]
 	path = feedstocks/r-rcolorbrewer
 	url = https://github.com/conda-forge/r-rcolorbrewer-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcpp"]
 	path = feedstocks/r-rcpp
 	url = https://github.com/conda-forge/r-rcpp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-registry"]
 	path = feedstocks/r-registry
 	url = https://github.com/conda-forge/r-registry-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rjson"]
 	path = feedstocks/r-rjson
 	url = https://github.com/conda-forge/r-rjson-feedstock.git
+	branch = refs/heads/master
 [submodule "r-stanheaders"]
 	path = feedstocks/r-stanheaders
 	url = https://github.com/conda-forge/r-stanheaders-feedstock.git
+	branch = refs/heads/master
 [submodule "r-stringdist"]
 	path = feedstocks/r-stringdist
 	url = https://github.com/conda-forge/r-stringdist-feedstock.git
+	branch = refs/heads/master
 [submodule "r-testit"]
 	path = feedstocks/r-testit
 	url = https://github.com/conda-forge/r-testit-feedstock.git
+	branch = refs/heads/master
 [submodule "r-timedate"]
 	path = feedstocks/r-timedate
 	url = https://github.com/conda-forge/r-timedate-feedstock.git
+	branch = refs/heads/master
 [submodule "r-vgam"]
 	path = feedstocks/r-vgam
 	url = https://github.com/conda-forge/r-vgam-feedstock.git
+	branch = refs/heads/master
 [submodule "r-viridislite"]
 	path = feedstocks/r-viridislite
 	url = https://github.com/conda-forge/r-viridislite-feedstock.git
+	branch = refs/heads/master
 [submodule "r-whisker"]
 	path = feedstocks/r-whisker
 	url = https://github.com/conda-forge/r-whisker-feedstock.git
+	branch = refs/heads/master
 [submodule "r-withr"]
 	path = feedstocks/r-withr
 	url = https://github.com/conda-forge/r-withr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-xml"]
 	path = feedstocks/r-xml
 	url = https://github.com/conda-forge/r-xml-feedstock.git
+	branch = refs/heads/master
 [submodule "r-xtable"]
 	path = feedstocks/r-xtable
 	url = https://github.com/conda-forge/r-xtable-feedstock.git
+	branch = refs/heads/master
 [submodule "r-yaml"]
 	path = feedstocks/r-yaml
 	url = https://github.com/conda-forge/r-yaml-feedstock.git
+	branch = refs/heads/master
 [submodule "r-zoo"]
 	path = feedstocks/r-zoo
 	url = https://github.com/conda-forge/r-zoo-feedstock.git
+	branch = refs/heads/master
 [submodule "records"]
 	path = feedstocks/records
 	url = https://github.com/conda-forge/records-feedstock.git
+	branch = refs/heads/master
 [submodule "conda-exec"]
 	path = feedstocks/conda-exec
 	url = https://github.com/conda-forge/conda-exec-feedstock.git
+	branch = refs/heads/master
 [submodule "et_xmlfile"]
 	path = feedstocks/et_xmlfile
 	url = https://github.com/conda-forge/et_xmlfile-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyterlab_launcher"]
 	path = feedstocks/jupyterlab_launcher
 	url = https://github.com/conda-forge/jupyterlab_launcher-feedstock.git
+	branch = refs/heads/master
 [submodule "rabbitmq-server"]
 	path = feedstocks/rabbitmq-server
 	url = https://github.com/conda-forge/rabbitmq-server-feedstock.git
+	branch = refs/heads/master
 [submodule "lancet"]
 	path = feedstocks/lancet
 	url = https://github.com/conda-forge/lancet-feedstock.git
+	branch = refs/heads/master
 [submodule "lesscpy"]
 	path = feedstocks/lesscpy
 	url = https://github.com/conda-forge/lesscpy-feedstock.git
+	branch = refs/heads/master
 [submodule "nbbrowserpdf"]
 	path = feedstocks/nbbrowserpdf
 	url = https://github.com/conda-forge/nbbrowserpdf-feedstock.git
+	branch = refs/heads/master
 [submodule "cdutil"]
 	path = feedstocks/cdutil
 	url = https://github.com/conda-forge/cdutil-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rjava"]
 	path = feedstocks/r-rjava
 	url = https://github.com/conda-forge/r-rjava-feedstock.git
+	branch = refs/heads/master
 [submodule "trollius"]
 	path = feedstocks/trollius
 	url = https://github.com/conda-forge/trollius-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rjsonio"]
 	path = feedstocks/r-rjsonio
 	url = https://github.com/conda-forge/r-rjsonio-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rodbc"]
 	path = feedstocks/r-rodbc
 	url = https://github.com/conda-forge/r-rodbc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rserve"]
 	path = feedstocks/r-rserve
 	url = https://github.com/conda-forge/r-rserve-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rstudioapi"]
 	path = feedstocks/r-rstudioapi
 	url = https://github.com/conda-forge/r-rstudioapi-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rzmq"]
 	path = feedstocks/r-rzmq
 	url = https://github.com/conda-forge/r-rzmq-feedstock.git
+	branch = refs/heads/master
 [submodule "r-slam"]
 	path = feedstocks/r-slam
 	url = https://github.com/conda-forge/r-slam-feedstock.git
+	branch = refs/heads/master
 [submodule "r-snowballc"]
 	path = feedstocks/r-snowballc
 	url = https://github.com/conda-forge/r-snowballc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sourcetools"]
 	path = feedstocks/r-sourcetools
 	url = https://github.com/conda-forge/r-sourcetools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sparsem"]
 	path = feedstocks/r-sparsem
 	url = https://github.com/conda-forge/r-sparsem-feedstock.git
+	branch = refs/heads/master
 [submodule "r-stabledist"]
 	path = feedstocks/r-stabledist
 	url = https://github.com/conda-forge/r-stabledist-feedstock.git
+	branch = refs/heads/master
 [submodule "python-nvd3"]
 	path = feedstocks/python-nvd3
 	url = https://github.com/conda-forge/python-nvd3-feedstock.git
+	branch = refs/heads/master
 [submodule "r-argparse"]
 	path = feedstocks/r-argparse
 	url = https://github.com/conda-forge/r-argparse-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bestglm"]
 	path = feedstocks/r-bestglm
 	url = https://github.com/conda-forge/r-bestglm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bit64"]
 	path = feedstocks/r-bit64
 	url = https://github.com/conda-forge/r-bit64-feedstock.git
+	branch = refs/heads/master
 [submodule "r-brglm"]
 	path = feedstocks/r-brglm
 	url = https://github.com/conda-forge/r-brglm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-catools"]
 	path = feedstocks/r-catools
 	url = https://github.com/conda-forge/r-catools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-coda"]
 	path = feedstocks/r-coda
 	url = https://github.com/conda-forge/r-coda-feedstock.git
+	branch = refs/heads/master
 [submodule "r-config"]
 	path = feedstocks/r-config
 	url = https://github.com/conda-forge/r-config-feedstock.git
+	branch = refs/heads/master
 [submodule "r-foreach"]
 	path = feedstocks/r-foreach
 	url = https://github.com/conda-forge/r-foreach-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gdata"]
 	path = feedstocks/r-gdata
 	url = https://github.com/conda-forge/r-gdata-feedstock.git
+	branch = refs/heads/master
 [submodule "r-glmnet"]
 	path = feedstocks/r-glmnet
 	url = https://github.com/conda-forge/r-glmnet-feedstock.git
+	branch = refs/heads/master
 [submodule "r-grpreg"]
 	path = feedstocks/r-grpreg
 	url = https://github.com/conda-forge/r-grpreg-feedstock.git
+	branch = refs/heads/master
 [submodule "r-openssl"]
 	path = feedstocks/r-openssl
 	url = https://github.com/conda-forge/r-openssl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pcapp"]
 	path = feedstocks/r-pcapp
 	url = https://github.com/conda-forge/r-pcapp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pki"]
 	path = feedstocks/r-pki
 	url = https://github.com/conda-forge/r-pki-feedstock.git
+	branch = refs/heads/master
 [submodule "r-plyr"]
 	path = feedstocks/r-plyr
 	url = https://github.com/conda-forge/r-plyr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-psych"]
 	path = feedstocks/r-psych
 	url = https://github.com/conda-forge/r-psych-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.oo"]
 	path = feedstocks/r-r.oo
 	url = https://github.com/conda-forge/r-r.oo-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcpparmadillo"]
 	path = feedstocks/r-rcpparmadillo
 	url = https://github.com/conda-forge/r-rcpparmadillo-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcurl"]
 	path = feedstocks/r-rcurl
 	url = https://github.com/conda-forge/r-rcurl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-reticulate"]
 	path = feedstocks/r-reticulate
 	url = https://github.com/conda-forge/r-reticulate-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tensorflow"]
 	path = feedstocks/r-tensorflow
 	url = https://github.com/conda-forge/r-tensorflow-feedstock.git
+	branch = refs/heads/master
 [submodule "r-testthat"]
 	path = feedstocks/r-testthat
 	url = https://github.com/conda-forge/r-testthat-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tibble"]
 	path = feedstocks/r-tibble
 	url = https://github.com/conda-forge/r-tibble-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tm"]
 	path = feedstocks/r-tm
 	url = https://github.com/conda-forge/r-tm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tokenizers"]
 	path = feedstocks/r-tokenizers
 	url = https://github.com/conda-forge/r-tokenizers-feedstock.git
+	branch = refs/heads/master
 [submodule "r-xlsxjars"]
 	path = feedstocks/r-xlsxjars
 	url = https://github.com/conda-forge/r-xlsxjars-feedstock.git
+	branch = refs/heads/master
 [submodule "r-xml2"]
 	path = feedstocks/r-xml2
 	url = https://github.com/conda-forge/r-xml2-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-swagger"]
 	path = feedstocks/flask-swagger
 	url = https://github.com/conda-forge/flask-swagger-feedstock.git
+	branch = refs/heads/master
 [submodule "psycogreen"]
 	path = feedstocks/psycogreen
 	url = https://github.com/conda-forge/psycogreen-feedstock.git
+	branch = refs/heads/master
 [submodule "r-cellranger"]
 	path = feedstocks/r-cellranger
 	url = https://github.com/conda-forge/r-cellranger-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gridextra"]
 	path = feedstocks/r-gridextra
 	url = https://github.com/conda-forge/r-gridextra-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hexbin"]
 	path = feedstocks/r-hexbin
 	url = https://github.com/conda-forge/r-hexbin-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hive"]
 	path = feedstocks/r-hive
 	url = https://github.com/conda-forge/r-hive-feedstock.git
+	branch = refs/heads/master
 [submodule "r-htmltools"]
 	path = feedstocks/r-htmltools
 	url = https://github.com/conda-forge/r-htmltools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-httpuv"]
 	path = feedstocks/r-httpuv
 	url = https://github.com/conda-forge/r-httpuv-feedstock.git
+	branch = refs/heads/master
 [submodule "r-httr"]
 	path = feedstocks/r-httr
 	url = https://github.com/conda-forge/r-httr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hunspell"]
 	path = feedstocks/r-hunspell
 	url = https://github.com/conda-forge/r-hunspell-feedstock.git
+	branch = refs/heads/master
 [submodule "r-latticeextra"]
 	path = feedstocks/r-latticeextra
 	url = https://github.com/conda-forge/r-latticeextra-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mapproj"]
 	path = feedstocks/r-mapproj
 	url = https://github.com/conda-forge/r-mapproj-feedstock.git
+	branch = refs/heads/master
 [submodule "r-markdown"]
 	path = feedstocks/r-markdown
 	url = https://github.com/conda-forge/r-markdown-feedstock.git
+	branch = refs/heads/master
 [submodule "r-memoise"]
 	path = feedstocks/r-memoise
 	url = https://github.com/conda-forge/r-memoise-feedstock.git
+	branch = refs/heads/master
 [submodule "r-minqa"]
 	path = feedstocks/r-minqa
 	url = https://github.com/conda-forge/r-minqa-feedstock.git
+	branch = refs/heads/master
 [submodule "r-modelmetrics"]
 	path = feedstocks/r-modelmetrics
 	url = https://github.com/conda-forge/r-modelmetrics-feedstock.git
+	branch = refs/heads/master
 [submodule "r-munsell"]
 	path = feedstocks/r-munsell
 	url = https://github.com/conda-forge/r-munsell-feedstock.git
+	branch = refs/heads/master
 [submodule "r-readxl"]
 	path = feedstocks/r-readxl
 	url = https://github.com/conda-forge/r-readxl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rematch"]
 	path = feedstocks/r-rematch
 	url = https://github.com/conda-forge/r-rematch-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rex"]
 	path = feedstocks/r-rex
 	url = https://github.com/conda-forge/r-rex-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rlist"]
 	path = feedstocks/r-rlist
 	url = https://github.com/conda-forge/r-rlist-feedstock.git
+	branch = refs/heads/master
 [submodule "r-robustbase"]
 	path = feedstocks/r-robustbase
 	url = https://github.com/conda-forge/r-robustbase-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rprojroot"]
 	path = feedstocks/r-rprojroot
 	url = https://github.com/conda-forge/r-rprojroot-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sp"]
 	path = feedstocks/r-sp
 	url = https://github.com/conda-forge/r-sp-feedstock.git
+	branch = refs/heads/master
 [submodule "rhash"]
 	path = feedstocks/rhash
 	url = https://github.com/conda-forge/rhash-feedstock.git
+	branch = refs/heads/master
 [submodule "neovim"]
 	path = feedstocks/neovim
 	url = https://github.com/conda-forge/neovim-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ape"]
 	path = feedstocks/r-ape
 	url = https://github.com/conda-forge/r-ape-feedstock.git
+	branch = refs/heads/master
 [submodule "r-commonmark"]
 	path = feedstocks/r-commonmark
 	url = https://github.com/conda-forge/r-commonmark-feedstock.git
+	branch = refs/heads/master
 [submodule "r-copula"]
 	path = feedstocks/r-copula
 	url = https://github.com/conda-forge/r-copula-feedstock.git
+	branch = refs/heads/master
 [submodule "r-cvtools"]
 	path = feedstocks/r-cvtools
 	url = https://github.com/conda-forge/r-cvtools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-desc"]
 	path = feedstocks/r-desc
 	url = https://github.com/conda-forge/r-desc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-devtools"]
 	path = feedstocks/r-devtools
 	url = https://github.com/conda-forge/r-devtools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-domc"]
 	path = feedstocks/r-domc
 	url = https://github.com/conda-forge/r-domc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-doparallel"]
 	path = feedstocks/r-doparallel
 	url = https://github.com/conda-forge/r-doparallel-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dplyr"]
 	path = feedstocks/r-dplyr
 	url = https://github.com/conda-forge/r-dplyr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-e1071"]
 	path = feedstocks/r-e1071
 	url = https://github.com/conda-forge/r-e1071-feedstock.git
+	branch = refs/heads/master
 [submodule "r-feather"]
 	path = feedstocks/r-feather
 	url = https://github.com/conda-forge/r-feather-feedstock.git
+	branch = refs/heads/master
 [submodule "r-forcats"]
 	path = feedstocks/r-forcats
 	url = https://github.com/conda-forge/r-forcats-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gplots"]
 	path = feedstocks/r-gplots
 	url = https://github.com/conda-forge/r-gplots-feedstock.git
+	branch = refs/heads/master
 [submodule "r-htmlwidgets"]
 	path = feedstocks/r-htmlwidgets
 	url = https://github.com/conda-forge/r-htmlwidgets-feedstock.git
+	branch = refs/heads/master
 [submodule "r-irlba"]
 	path = feedstocks/r-irlba
 	url = https://github.com/conda-forge/r-irlba-feedstock.git
+	branch = refs/heads/master
 [submodule "r-kohonen"]
 	path = feedstocks/r-kohonen
 	url = https://github.com/conda-forge/r-kohonen-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lmtest"]
 	path = feedstocks/r-lmtest
 	url = https://github.com/conda-forge/r-lmtest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lubridate"]
 	path = feedstocks/r-lubridate
 	url = https://github.com/conda-forge/r-lubridate-feedstock.git
+	branch = refs/heads/master
 [submodule "r-maptools"]
 	path = feedstocks/r-maptools
 	url = https://github.com/conda-forge/r-maptools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-matrixmodels"]
 	path = feedstocks/r-matrixmodels
 	url = https://github.com/conda-forge/r-matrixmodels-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nycflights13"]
 	path = feedstocks/r-nycflights13
 	url = https://github.com/conda-forge/r-nycflights13-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pkgmaker"]
 	path = feedstocks/r-pkgmaker
 	url = https://github.com/conda-forge/r-pkgmaker-feedstock.git
+	branch = refs/heads/master
 [submodule "r-proc"]
 	path = feedstocks/r-proc
 	url = https://github.com/conda-forge/r-proc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pryr"]
 	path = feedstocks/r-pryr
 	url = https://github.com/conda-forge/r-pryr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.utils"]
 	path = feedstocks/r-r.utils
 	url = https://github.com/conda-forge/r-r.utils-feedstock.git
+	branch = refs/heads/master
 [submodule "r-raster"]
 	path = feedstocks/r-raster
 	url = https://github.com/conda-forge/r-raster-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcppeigen"]
 	path = feedstocks/r-rcppeigen
 	url = https://github.com/conda-forge/r-rcppeigen-feedstock.git
+	branch = refs/heads/master
 [submodule "r-readr"]
 	path = feedstocks/r-readr
 	url = https://github.com/conda-forge/r-readr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-reshape"]
 	path = feedstocks/r-reshape
 	url = https://github.com/conda-forge/r-reshape-feedstock.git
+	branch = refs/heads/master
 [submodule "r-reshape2"]
 	path = feedstocks/r-reshape2
 	url = https://github.com/conda-forge/r-reshape2-feedstock.git
+	branch = refs/heads/master
 [submodule "r-roxygen2"]
 	path = feedstocks/r-roxygen2
 	url = https://github.com/conda-forge/r-roxygen2-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rsconnect"]
 	path = feedstocks/r-rsconnect
 	url = https://github.com/conda-forge/r-rsconnect-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rsqlite"]
 	path = feedstocks/r-rsqlite
 	url = https://github.com/conda-forge/r-rsqlite-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rversions"]
 	path = feedstocks/r-rversions
 	url = https://github.com/conda-forge/r-rversions-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sandwich"]
 	path = feedstocks/r-sandwich
 	url = https://github.com/conda-forge/r-sandwich-feedstock.git
+	branch = refs/heads/master
 [submodule "r-scales"]
 	path = feedstocks/r-scales
 	url = https://github.com/conda-forge/r-scales-feedstock.git
+	branch = refs/heads/master
 [submodule "r-seacarb"]
 	path = feedstocks/r-seacarb
 	url = https://github.com/conda-forge/r-seacarb-feedstock.git
+	branch = refs/heads/master
 [submodule "r-selectr"]
 	path = feedstocks/r-selectr
 	url = https://github.com/conda-forge/r-selectr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sf"]
 	path = feedstocks/r-sf
 	url = https://github.com/conda-forge/r-sf-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shiny"]
 	path = feedstocks/r-shiny
 	url = https://github.com/conda-forge/r-shiny-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shinythemes"]
 	path = feedstocks/r-shinythemes
 	url = https://github.com/conda-forge/r-shinythemes-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sparklyr"]
 	path = feedstocks/r-sparklyr
 	url = https://github.com/conda-forge/r-sparklyr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-strucchange"]
 	path = feedstocks/r-strucchange
 	url = https://github.com/conda-forge/r-strucchange-feedstock.git
+	branch = refs/heads/master
 [submodule "r-th.data"]
 	path = feedstocks/r-th.data
 	url = https://github.com/conda-forge/r-th.data-feedstock.git
+	branch = refs/heads/master
 [submodule "r-threejs"]
 	path = feedstocks/r-threejs
 	url = https://github.com/conda-forge/r-threejs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tidyr"]
 	path = feedstocks/r-tidyr
 	url = https://github.com/conda-forge/r-tidyr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tilegramsr"]
 	path = feedstocks/r-tilegramsr
 	url = https://github.com/conda-forge/r-tilegramsr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tseries"]
 	path = feedstocks/r-tseries
 	url = https://github.com/conda-forge/r-tseries-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ttr"]
 	path = feedstocks/r-ttr
 	url = https://github.com/conda-forge/r-ttr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-udunits2"]
 	path = feedstocks/r-udunits2
 	url = https://github.com/conda-forge/r-udunits2-feedstock.git
+	branch = refs/heads/master
 [submodule "r-units"]
 	path = feedstocks/r-units
 	url = https://github.com/conda-forge/r-units-feedstock.git
+	branch = refs/heads/master
 [submodule "r-urca"]
 	path = feedstocks/r-urca
 	url = https://github.com/conda-forge/r-urca-feedstock.git
+	branch = refs/heads/master
 [submodule "r-visnetwork"]
 	path = feedstocks/r-visnetwork
 	url = https://github.com/conda-forge/r-visnetwork-feedstock.git
+	branch = refs/heads/master
 [submodule "r-weatherdata"]
 	path = feedstocks/r-weatherdata
 	url = https://github.com/conda-forge/r-weatherdata-feedstock.git
+	branch = refs/heads/master
 [submodule "r-xlsx"]
 	path = feedstocks/r-xlsx
 	url = https://github.com/conda-forge/r-xlsx-feedstock.git
+	branch = refs/heads/master
 [submodule "r-xts"]
 	path = feedstocks/r-xts
 	url = https://github.com/conda-forge/r-xts-feedstock.git
+	branch = refs/heads/master
 [submodule "axelrod"]
 	path = feedstocks/axelrod
 	url = https://github.com/conda-forge/axelrod-feedstock.git
+	branch = refs/heads/master
 [submodule "cypari2"]
 	path = feedstocks/cypari2
 	url = https://github.com/conda-forge/cypari2-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-rest-jsonapi"]
 	path = feedstocks/flask-rest-jsonapi
 	url = https://github.com/conda-forge/flask-rest-jsonapi-feedstock.git
+	branch = refs/heads/master
 [submodule "marshmallow-jsonapi"]
 	path = feedstocks/marshmallow-jsonapi
 	url = https://github.com/conda-forge/marshmallow-jsonapi-feedstock.git
+	branch = refs/heads/master
 [submodule "qd"]
 	path = feedstocks/qd
 	url = https://github.com/conda-forge/qd-feedstock.git
+	branch = refs/heads/master
 [submodule "r-anomalydetection"]
 	path = feedstocks/r-anomalydetection
 	url = https://github.com/conda-forge/r-anomalydetection-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bradleyterry2"]
 	path = feedstocks/r-bradleyterry2
 	url = https://github.com/conda-forge/r-bradleyterry2-feedstock.git
+	branch = refs/heads/master
 [submodule "r-broom"]
 	path = feedstocks/r-broom
 	url = https://github.com/conda-forge/r-broom-feedstock.git
+	branch = refs/heads/master
 [submodule "r-car"]
 	path = feedstocks/r-car
 	url = https://github.com/conda-forge/r-car-feedstock.git
+	branch = refs/heads/master
 [submodule "r-caret"]
 	path = feedstocks/r-caret
 	url = https://github.com/conda-forge/r-caret-feedstock.git
+	branch = refs/heads/master
 [submodule "r-crosstalk"]
 	path = feedstocks/r-crosstalk
 	url = https://github.com/conda-forge/r-crosstalk-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dt"]
 	path = feedstocks/r-dt
 	url = https://github.com/conda-forge/r-dt-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dygraphs"]
 	path = feedstocks/r-dygraphs
 	url = https://github.com/conda-forge/r-dygraphs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-forecast"]
 	path = feedstocks/r-forecast
 	url = https://github.com/conda-forge/r-forecast-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fwdselect"]
 	path = feedstocks/r-fwdselect
 	url = https://github.com/conda-forge/r-fwdselect-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggplot2"]
 	path = feedstocks/r-ggplot2
 	url = https://github.com/conda-forge/r-ggplot2-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggvis"]
 	path = feedstocks/r-ggvis
 	url = https://github.com/conda-forge/r-ggvis-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gmp"]
 	path = feedstocks/r-gmp
 	url = https://github.com/conda-forge/r-gmp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-haven"]
 	path = feedstocks/r-haven
 	url = https://github.com/conda-forge/r-haven-feedstock.git
+	branch = refs/heads/master
 [submodule "r-htmltable"]
 	path = feedstocks/r-htmltable
 	url = https://github.com/conda-forge/r-htmltable-feedstock.git
+	branch = refs/heads/master
 [submodule "r-knitr"]
 	path = feedstocks/r-knitr
 	url = https://github.com/conda-forge/r-knitr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lahman"]
 	path = feedstocks/r-lahman
 	url = https://github.com/conda-forge/r-lahman-feedstock.git
+	branch = refs/heads/master
 [submodule "r-leaflet"]
 	path = feedstocks/r-leaflet
 	url = https://github.com/conda-forge/r-leaflet-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lme4"]
 	path = feedstocks/r-lme4
 	url = https://github.com/conda-forge/r-lme4-feedstock.git
+	branch = refs/heads/master
 [submodule "r-matrixstats"]
 	path = feedstocks/r-matrixstats
 	url = https://github.com/conda-forge/r-matrixstats-feedstock.git
+	branch = refs/heads/master
 [submodule "r-microbenchmark"]
 	path = feedstocks/r-microbenchmark
 	url = https://github.com/conda-forge/r-microbenchmark-feedstock.git
+	branch = refs/heads/master
 [submodule "r-miniui"]
 	path = feedstocks/r-miniui
 	url = https://github.com/conda-forge/r-miniui-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mlmrev"]
 	path = feedstocks/r-mlmrev
 	url = https://github.com/conda-forge/r-mlmrev-feedstock.git
+	branch = refs/heads/master
 [submodule "r-modelr"]
 	path = feedstocks/r-modelr
 	url = https://github.com/conda-forge/r-modelr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-multcomp"]
 	path = feedstocks/r-multcomp
 	url = https://github.com/conda-forge/r-multcomp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nmf"]
 	path = feedstocks/r-nmf
 	url = https://github.com/conda-forge/r-nmf-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pbkrtest"]
 	path = feedstocks/r-pbkrtest
 	url = https://github.com/conda-forge/r-pbkrtest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-purrr"]
 	path = feedstocks/r-purrr
 	url = https://github.com/conda-forge/r-purrr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-qdaptools"]
 	path = feedstocks/r-qdaptools
 	url = https://github.com/conda-forge/r-qdaptools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-quantmod"]
 	path = feedstocks/r-quantmod
 	url = https://github.com/conda-forge/r-quantmod-feedstock.git
+	branch = refs/heads/master
 [submodule "r-quantreg"]
 	path = feedstocks/r-quantreg
 	url = https://github.com/conda-forge/r-quantreg-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rgl"]
 	path = feedstocks/r-rgl
 	url = https://github.com/conda-forge/r-rgl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rmarkdown"]
 	path = feedstocks/r-rmarkdown
 	url = https://github.com/conda-forge/r-rmarkdown-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rmr2"]
 	path = feedstocks/r-rmr2
 	url = https://github.com/conda-forge/r-rmr2-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rngtools"]
 	path = feedstocks/r-rngtools
 	url = https://github.com/conda-forge/r-rngtools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rocr"]
 	path = feedstocks/r-rocr
 	url = https://github.com/conda-forge/r-rocr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rstan"]
 	path = feedstocks/r-rstan
 	url = https://github.com/conda-forge/r-rstan-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rvest"]
 	path = feedstocks/r-rvest
 	url = https://github.com/conda-forge/r-rvest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shinybs"]
 	path = feedstocks/r-shinybs
 	url = https://github.com/conda-forge/r-shinybs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shinydashboard"]
 	path = feedstocks/r-shinydashboard
 	url = https://github.com/conda-forge/r-shinydashboard-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shinyjs"]
 	path = feedstocks/r-shinyjs
 	url = https://github.com/conda-forge/r-shinyjs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shinysky"]
 	path = feedstocks/r-shinysky
 	url = https://github.com/conda-forge/r-shinysky-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tidyverse"]
 	path = feedstocks/r-tidyverse
 	url = https://github.com/conda-forge/r-tidyverse-feedstock.git
+	branch = refs/heads/master
 [submodule "r-vars"]
 	path = feedstocks/r-vars
 	url = https://github.com/conda-forge/r-vars-feedstock.git
+	branch = refs/heads/master
 [submodule "r-viridis"]
 	path = feedstocks/r-viridis
 	url = https://github.com/conda-forge/r-viridis-feedstock.git
+	branch = refs/heads/master
 [submodule "scripttest"]
 	path = feedstocks/scripttest
 	url = https://github.com/conda-forge/scripttest-feedstock.git
+	branch = refs/heads/master
 [submodule "flup"]
 	path = feedstocks/flup
 	url = https://github.com/conda-forge/flup-feedstock.git
+	branch = refs/heads/master
 [submodule "pyfiglet"]
 	path = feedstocks/pyfiglet
 	url = https://github.com/conda-forge/pyfiglet-feedstock.git
+	branch = refs/heads/master
 [submodule "r-checkmate"]
 	path = feedstocks/r-checkmate
 	url = https://github.com/conda-forge/r-checkmate-feedstock.git
+	branch = refs/heads/master
 [submodule "fastnumbers"]
 	path = feedstocks/fastnumbers
 	url = https://github.com/conda-forge/fastnumbers-feedstock.git
+	branch = refs/heads/master
 [submodule "r-coin"]
 	path = feedstocks/r-coin
 	url = https://github.com/conda-forge/r-coin-feedstock.git
+	branch = refs/heads/master
 [submodule "r-formattable"]
 	path = feedstocks/r-formattable
 	url = https://github.com/conda-forge/r-formattable-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gistr"]
 	path = feedstocks/r-gistr
 	url = https://github.com/conda-forge/r-gistr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hmisc"]
 	path = feedstocks/r-hmisc
 	url = https://github.com/conda-forge/r-hmisc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-igraph"]
 	path = feedstocks/r-igraph
 	url = https://github.com/conda-forge/r-igraph-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lsmeans"]
 	path = feedstocks/r-lsmeans
 	url = https://github.com/conda-forge/r-lsmeans-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tidytext"]
 	path = feedstocks/r-tidytext
 	url = https://github.com/conda-forge/r-tidytext-feedstock.git
+	branch = refs/heads/master
 [submodule "aiohttp"]
 	path = feedstocks/aiohttp
 	url = https://github.com/conda-forge/aiohttp-feedstock.git
+	branch = refs/heads/master
 [submodule "async-timeout"]
 	path = feedstocks/async-timeout
 	url = https://github.com/conda-forge/async-timeout-feedstock.git
+	branch = refs/heads/master
 [submodule "jsonapi-client"]
 	path = feedstocks/jsonapi-client
 	url = https://github.com/conda-forge/jsonapi-client-feedstock.git
+	branch = refs/heads/master
 [submodule "multidict"]
 	path = feedstocks/multidict
 	url = https://github.com/conda-forge/multidict-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-asyncio"]
 	path = feedstocks/pytest-asyncio
 	url = https://github.com/conda-forge/pytest-asyncio-feedstock.git
+	branch = refs/heads/master
 [submodule "r-aer"]
 	path = feedstocks/r-aer
 	url = https://github.com/conda-forge/r-aer-feedstock.git
+	branch = refs/heads/master
 [submodule "r-afex"]
 	path = feedstocks/r-afex
 	url = https://github.com/conda-forge/r-afex-feedstock.git
+	branch = refs/heads/master
 [submodule "r-diagrammer"]
 	path = feedstocks/r-diagrammer
 	url = https://github.com/conda-forge/r-diagrammer-feedstock.git
+	branch = refs/heads/master
 [submodule "r-essentials"]
 	path = feedstocks/r-essentials
 	url = https://github.com/conda-forge/r-essentials-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gsubfn"]
 	path = feedstocks/r-gsubfn
 	url = https://github.com/conda-forge/r-gsubfn-feedstock.git
+	branch = refs/heads/master
 [submodule "r-highcharter"]
 	path = feedstocks/r-highcharter
 	url = https://github.com/conda-forge/r-highcharter-feedstock.git
+	branch = refs/heads/master
 [submodule "r-influencer"]
 	path = feedstocks/r-influencer
 	url = https://github.com/conda-forge/r-influencer-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lintr"]
 	path = feedstocks/r-lintr
 	url = https://github.com/conda-forge/r-lintr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lmertest"]
 	path = feedstocks/r-lmertest
 	url = https://github.com/conda-forge/r-lmertest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-networkd3"]
 	path = feedstocks/r-networkd3
 	url = https://github.com/conda-forge/r-networkd3-feedstock.git
+	branch = refs/heads/master
 [submodule "r-plm"]
 	path = feedstocks/r-plm
 	url = https://github.com/conda-forge/r-plm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rbokeh"]
 	path = feedstocks/r-rbokeh
 	url = https://github.com/conda-forge/r-rbokeh-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rgexf"]
 	path = feedstocks/r-rgexf
 	url = https://github.com/conda-forge/r-rgexf-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rook"]
 	path = feedstocks/r-rook
 	url = https://github.com/conda-forge/r-rook-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sqldf"]
 	path = feedstocks/r-sqldf
 	url = https://github.com/conda-forge/r-sqldf-feedstock.git
+	branch = refs/heads/master
 [submodule "yarl"]
 	path = feedstocks/yarl
 	url = https://github.com/conda-forge/yarl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-cowplot"]
 	path = feedstocks/r-cowplot
 	url = https://github.com/conda-forge/r-cowplot-feedstock.git
+	branch = refs/heads/master
 [submodule "r-geosphere"]
 	path = feedstocks/r-geosphere
 	url = https://github.com/conda-forge/r-geosphere-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggmap"]
 	path = feedstocks/r-ggmap
 	url = https://github.com/conda-forge/r-ggmap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pracma"]
 	path = feedstocks/r-pracma
 	url = https://github.com/conda-forge/r-pracma-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rgooglemaps"]
 	path = feedstocks/r-rgooglemaps
 	url = https://github.com/conda-forge/r-rgooglemaps-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-ndfilters"]
 	path = feedstocks/dask-ndfilters
 	url = https://github.com/conda-forge/dask-ndfilters-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ddrtree"]
 	path = feedstocks/r-ddrtree
 	url = https://github.com/conda-forge/r-ddrtree-feedstock.git
+	branch = refs/heads/master
 [submodule "r-densityclust"]
 	path = feedstocks/r-densityclust
 	url = https://github.com/conda-forge/r-densityclust-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fastica"]
 	path = feedstocks/r-fastica
 	url = https://github.com/conda-forge/r-fastica-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggfortify"]
 	path = feedstocks/r-ggfortify
 	url = https://github.com/conda-forge/r-ggfortify-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mapdata"]
 	path = feedstocks/r-mapdata
 	url = https://github.com/conda-forge/r-mapdata-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ncdf4"]
 	path = feedstocks/r-ncdf4
 	url = https://github.com/conda-forge/r-ncdf4-feedstock.git
+	branch = refs/heads/master
 [submodule "r-proxy"]
 	path = feedstocks/r-proxy
 	url = https://github.com/conda-forge/r-proxy-feedstock.git
+	branch = refs/heads/master
 [submodule "r-qlcmatrix"]
 	path = feedstocks/r-qlcmatrix
 	url = https://github.com/conda-forge/r-qlcmatrix-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rerddap"]
 	path = feedstocks/r-rerddap
 	url = https://github.com/conda-forge/r-rerddap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-xtractomatic"]
 	path = feedstocks/r-xtractomatic
 	url = https://github.com/conda-forge/r-xtractomatic-feedstock.git
+	branch = refs/heads/master
 [submodule "xattr"]
 	path = feedstocks/xattr
 	url = https://github.com/conda-forge/xattr-feedstock.git
+	branch = refs/heads/master
 [submodule "zopfli"]
 	path = feedstocks/zopfli
 	url = https://github.com/conda-forge/zopfli-feedstock.git
+	branch = refs/heads/master
 [submodule "nbfinder"]
 	path = feedstocks/nbfinder
 	url = https://github.com/conda-forge/nbfinder-feedstock.git
+	branch = refs/heads/master
 [submodule "eli5"]
 	path = feedstocks/eli5
 	url = https://github.com/conda-forge/eli5-feedstock.git
+	branch = refs/heads/master
 [submodule "pyobjc-core"]
 	path = feedstocks/pyobjc-core
 	url = https://github.com/conda-forge/pyobjc-core-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-ast-back-to-python"]
 	path = feedstocks/pytest-ast-back-to-python
 	url = https://github.com/conda-forge/pytest-ast-back-to-python-feedstock.git
+	branch = refs/heads/master
 [submodule "lzfse"]
 	path = feedstocks/lzfse
 	url = https://github.com/conda-forge/lzfse-feedstock.git
+	branch = refs/heads/master
 [submodule "ijson"]
 	path = feedstocks/ijson
 	url = https://github.com/conda-forge/ijson-feedstock.git
+	branch = refs/heads/master
 [submodule "backports.csv"]
 	path = feedstocks/backports.csv
 	url = https://github.com/conda-forge/backports.csv-feedstock.git
+	branch = refs/heads/master
 [submodule "cld2-cffi"]
 	path = feedstocks/cld2-cffi
 	url = https://github.com/conda-forge/cld2-cffi-feedstock.git
+	branch = refs/heads/master
 [submodule "concurrentloghandler"]
 	path = feedstocks/concurrentloghandler
 	url = https://github.com/conda-forge/concurrentloghandler-feedstock.git
+	branch = refs/heads/master
 [submodule "jsonapi-requests"]
 	path = feedstocks/jsonapi-requests
 	url = https://github.com/conda-forge/jsonapi-requests-feedstock.git
+	branch = refs/heads/master
 [submodule "pyedflib"]
 	path = feedstocks/pyedflib
 	url = https://github.com/conda-forge/pyedflib-feedstock.git
+	branch = refs/heads/master
 [submodule "pyemd"]
 	path = feedstocks/pyemd
 	url = https://github.com/conda-forge/pyemd-feedstock.git
+	branch = refs/heads/master
 [submodule "pyphen"]
 	path = feedstocks/pyphen
 	url = https://github.com/conda-forge/pyphen-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rmysql"]
 	path = feedstocks/r-rmysql
 	url = https://github.com/conda-forge/r-rmysql-feedstock.git
+	branch = refs/heads/master
 [submodule "tenacity"]
 	path = feedstocks/tenacity
 	url = https://github.com/conda-forge/tenacity-feedstock.git
+	branch = refs/heads/master
 [submodule "apsw"]
 	path = feedstocks/apsw
 	url = https://github.com/conda-forge/apsw-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-ndfourier"]
 	path = feedstocks/dask-ndfourier
 	url = https://github.com/conda-forge/dask-ndfourier-feedstock.git
+	branch = refs/heads/master
 [submodule "dose"]
 	path = feedstocks/dose
 	url = https://github.com/conda-forge/dose-feedstock.git
+	branch = refs/heads/master
 [submodule "graph"]
 	path = feedstocks/graph
 	url = https://github.com/conda-forge/graph-feedstock.git
+	branch = refs/heads/master
 [submodule "pvl"]
 	path = feedstocks/pvl
 	url = https://github.com/conda-forge/pvl-feedstock.git
+	branch = refs/heads/master
 [submodule "sep"]
 	path = feedstocks/sep
 	url = https://github.com/conda-forge/sep-feedstock.git
+	branch = refs/heads/master
 [submodule "setuptools_subversion"]
 	path = feedstocks/setuptools_subversion
 	url = https://github.com/conda-forge/setuptools_subversion-feedstock.git
+	branch = refs/heads/master
 [submodule "airflow"]
 	path = feedstocks/airflow
 	url = https://github.com/conda-forge/airflow-feedstock.git
+	branch = refs/heads/master
 [submodule "dolfyn"]
 	path = feedstocks/dolfyn
 	url = https://github.com/conda-forge/dolfyn-feedstock.git
+	branch = refs/heads/master
 [submodule "gazar"]
 	path = feedstocks/gazar
 	url = https://github.com/conda-forge/gazar-feedstock.git
+	branch = refs/heads/master
 [submodule "rfc3339"]
 	path = feedstocks/rfc3339
 	url = https://github.com/conda-forge/rfc3339-feedstock.git
+	branch = refs/heads/master
 [submodule "rpy2"]
 	path = feedstocks/rpy2
 	url = https://github.com/conda-forge/rpy2-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-rf"]
 	path = feedstocks/scikit-rf
 	url = https://github.com/conda-forge/scikit-rf-feedstock.git
+	branch = refs/heads/master
 [submodule "textacy"]
 	path = feedstocks/textacy
 	url = https://github.com/conda-forge/textacy-feedstock.git
+	branch = refs/heads/master
 [submodule "sfdmap"]
 	path = feedstocks/sfdmap
 	url = https://github.com/conda-forge/sfdmap-feedstock.git
+	branch = refs/heads/master
 [submodule "sncosmo"]
 	path = feedstocks/sncosmo
 	url = https://github.com/conda-forge/sncosmo-feedstock.git
+	branch = refs/heads/master
 [submodule "pangaea"]
 	path = feedstocks/pangaea
 	url = https://github.com/conda-forge/pangaea-feedstock.git
+	branch = refs/heads/master
 [submodule "simple-salesforce"]
 	path = feedstocks/simple-salesforce
 	url = https://github.com/conda-forge/simple-salesforce-feedstock.git
+	branch = refs/heads/master
 [submodule "zstandard"]
 	path = feedstocks/zstandard
 	url = https://github.com/conda-forge/zstandard-feedstock.git
+	branch = refs/heads/master
 [submodule "blessings"]
 	path = feedstocks/blessings
 	url = https://github.com/conda-forge/blessings-feedstock.git
+	branch = refs/heads/master
 [submodule "glimix-core"]
 	path = feedstocks/glimix-core
 	url = https://github.com/conda-forge/glimix-core-feedstock.git
+	branch = refs/heads/master
 [submodule "greenlet"]
 	path = feedstocks/greenlet
 	url = https://github.com/conda-forge/greenlet-feedstock.git
+	branch = refs/heads/master
 [submodule "jftools"]
 	path = feedstocks/jftools
 	url = https://github.com/conda-forge/jftools-feedstock.git
+	branch = refs/heads/master
 [submodule "limix-core"]
 	path = feedstocks/limix-core
 	url = https://github.com/conda-forge/limix-core-feedstock.git
+	branch = refs/heads/master
 [submodule "limix-legacy"]
 	path = feedstocks/limix-legacy
 	url = https://github.com/conda-forge/limix-legacy-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxcontrib-websupport"]
 	path = feedstocks/sphinxcontrib-websupport
 	url = https://github.com/conda-forge/sphinxcontrib-websupport-feedstock.git
+	branch = refs/heads/master
 [submodule "lzstring"]
 	path = feedstocks/lzstring
 	url = https://github.com/conda-forge/lzstring-feedstock.git
+	branch = refs/heads/master
 [submodule "mizani"]
 	path = feedstocks/mizani
 	url = https://github.com/conda-forge/mizani-feedstock.git
+	branch = refs/heads/master
 [submodule "planetaryimage"]
 	path = feedstocks/planetaryimage
 	url = https://github.com/conda-forge/planetaryimage-feedstock.git
+	branch = refs/heads/master
 [submodule "plotnine"]
 	path = feedstocks/plotnine
 	url = https://github.com/conda-forge/plotnine-feedstock.git
+	branch = refs/heads/master
 [submodule "case"]
 	path = feedstocks/case
 	url = https://github.com/conda-forge/case-feedstock.git
+	branch = refs/heads/master
 [submodule "cfunits"]
 	path = feedstocks/cfunits
 	url = https://github.com/conda-forge/cfunits-feedstock.git
+	branch = refs/heads/master
 [submodule "ciso8601"]
 	path = feedstocks/ciso8601
 	url = https://github.com/conda-forge/ciso8601-feedstock.git
+	branch = refs/heads/master
 [submodule "cvloop"]
 	path = feedstocks/cvloop
 	url = https://github.com/conda-forge/cvloop-feedstock.git
+	branch = refs/heads/master
 [submodule "aloe"]
 	path = feedstocks/aloe
 	url = https://github.com/conda-forge/aloe-feedstock.git
+	branch = refs/heads/master
 [submodule "cson"]
 	path = feedstocks/cson
 	url = https://github.com/conda-forge/cson-feedstock.git
+	branch = refs/heads/master
 [submodule "gherkin-official"]
 	path = feedstocks/gherkin-official
 	url = https://github.com/conda-forge/gherkin-official-feedstock.git
+	branch = refs/heads/master
 [submodule "orange3-geo"]
 	path = feedstocks/orange3-geo
 	url = https://github.com/conda-forge/orange3-geo-feedstock.git
+	branch = refs/heads/master
 [submodule "speg"]
 	path = feedstocks/speg
 	url = https://github.com/conda-forge/speg-feedstock.git
+	branch = refs/heads/master
 [submodule "cibots"]
 	path = feedstocks/cibots
 	url = https://github.com/conda-forge/cibots-feedstock.git
+	branch = refs/heads/master
 [submodule "colormath"]
 	path = feedstocks/colormath
 	url = https://github.com/conda-forge/colormath-feedstock.git
+	branch = refs/heads/master
 [submodule "easyprocess"]
 	path = feedstocks/easyprocess
 	url = https://github.com/conda-forge/easyprocess-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-webpack"]
 	path = feedstocks/flask-webpack
 	url = https://github.com/conda-forge/flask-webpack-feedstock.git
+	branch = refs/heads/master
 [submodule "lemon"]
 	path = feedstocks/lemon
 	url = https://github.com/conda-forge/lemon-feedstock.git
+	branch = refs/heads/master
 [submodule "mppp"]
 	path = feedstocks/mppp
 	url = https://github.com/conda-forge/mppp-feedstock.git
+	branch = refs/heads/master
 [submodule "pyrepl"]
 	path = feedstocks/pyrepl
 	url = https://github.com/conda-forge/pyrepl-feedstock.git
+	branch = refs/heads/master
 [submodule "wtforms"]
 	path = feedstocks/wtforms
 	url = https://github.com/conda-forge/wtforms-feedstock.git
+	branch = refs/heads/master
 [submodule "xlsxwriter"]
 	path = feedstocks/xlsxwriter
 	url = https://github.com/conda-forge/xlsxwriter-feedstock.git
+	branch = refs/heads/master
 [submodule "spectra"]
 	path = feedstocks/spectra
 	url = https://github.com/conda-forge/spectra-feedstock.git
+	branch = refs/heads/master
 [submodule "dawg"]
 	path = feedstocks/dawg
 	url = https://github.com/conda-forge/dawg-feedstock.git
+	branch = refs/heads/master
 [submodule "link-traits"]
 	path = feedstocks/link-traits
 	url = https://github.com/conda-forge/link-traits-feedstock.git
+	branch = refs/heads/master
 [submodule "xrft"]
 	path = feedstocks/xrft
 	url = https://github.com/conda-forge/xrft-feedstock.git
+	branch = refs/heads/master
 [submodule "xorg-libxrandr"]
 	path = feedstocks/xorg-libxrandr
 	url = https://github.com/conda-forge/xorg-libxrandr-feedstock.git
+	branch = refs/heads/master
 [submodule "fancycompleter"]
 	path = feedstocks/fancycompleter
 	url = https://github.com/conda-forge/fancycompleter-feedstock.git
+	branch = refs/heads/master
 [submodule "gmaps"]
 	path = feedstocks/gmaps
 	url = https://github.com/conda-forge/gmaps-feedstock.git
+	branch = refs/heads/master
 [submodule "kafka-python"]
 	path = feedstocks/kafka-python
 	url = https://github.com/conda-forge/kafka-python-feedstock.git
+	branch = refs/heads/master
 [submodule "lftp"]
 	path = feedstocks/lftp
 	url = https://github.com/conda-forge/lftp-feedstock.git
+	branch = refs/heads/master
 [submodule "openmotif"]
 	path = feedstocks/openmotif
 	url = https://github.com/conda-forge/openmotif-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-base-url"]
 	path = feedstocks/pytest-base-url
 	url = https://github.com/conda-forge/pytest-base-url-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-metadata"]
 	path = feedstocks/pytest-metadata
 	url = https://github.com/conda-forge/pytest-metadata-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-variables"]
 	path = feedstocks/pytest-variables
 	url = https://github.com/conda-forge/pytest-variables-feedstock.git
+	branch = refs/heads/master
 [submodule "signac-flow"]
 	path = feedstocks/signac-flow
 	url = https://github.com/conda-forge/signac-flow-feedstock.git
+	branch = refs/heads/master
 [submodule "twython"]
 	path = feedstocks/twython
 	url = https://github.com/conda-forge/twython-feedstock.git
+	branch = refs/heads/master
 [submodule "xtensor-blas"]
 	path = feedstocks/xtensor-blas
 	url = https://github.com/conda-forge/xtensor-blas-feedstock.git
+	branch = refs/heads/master
 [submodule "sarge"]
 	path = feedstocks/sarge
 	url = https://github.com/conda-forge/sarge-feedstock.git
+	branch = refs/heads/master
 [submodule "joommfutil"]
 	path = feedstocks/joommfutil
 	url = https://github.com/conda-forge/joommfutil-feedstock.git
+	branch = refs/heads/master
 [submodule "oommfodt"]
 	path = feedstocks/oommfodt
 	url = https://github.com/conda-forge/oommfodt-feedstock.git
+	branch = refs/heads/master
 [submodule "oommf"]
 	path = feedstocks/oommf
 	url = https://github.com/conda-forge/oommf-feedstock.git
+	branch = refs/heads/master
 [submodule "pyvtk"]
 	path = feedstocks/pyvtk
 	url = https://github.com/conda-forge/pyvtk-feedstock.git
+	branch = refs/heads/master
 [submodule "rebound"]
 	path = feedstocks/rebound
 	url = https://github.com/conda-forge/rebound-feedstock.git
+	branch = refs/heads/master
 [submodule "yarn"]
 	path = feedstocks/yarn
 	url = https://github.com/conda-forge/yarn-feedstock.git
+	branch = refs/heads/master
 [submodule "backoff"]
 	path = feedstocks/backoff
 	url = https://github.com/conda-forge/backoff-feedstock.git
+	branch = refs/heads/master
 [submodule "discretisedfield"]
 	path = feedstocks/discretisedfield
 	url = https://github.com/conda-forge/discretisedfield-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-html"]
 	path = feedstocks/pytest-html
 	url = https://github.com/conda-forge/pytest-html-feedstock.git
+	branch = refs/heads/master
 [submodule "simpletal"]
 	path = feedstocks/simpletal
 	url = https://github.com/conda-forge/simpletal-feedstock.git
+	branch = refs/heads/master
 [submodule "vitables"]
 	path = feedstocks/vitables
 	url = https://github.com/conda-forge/vitables-feedstock.git
+	branch = refs/heads/master
 [submodule "svglib"]
 	path = feedstocks/svglib
 	url = https://github.com/conda-forge/svglib-feedstock.git
+	branch = refs/heads/master
 [submodule "fire"]
 	path = feedstocks/fire
 	url = https://github.com/conda-forge/fire-feedstock.git
+	branch = refs/heads/master
 [submodule "progress"]
 	path = feedstocks/progress
 	url = https://github.com/conda-forge/progress-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-selenium"]
 	path = feedstocks/pytest-selenium
 	url = https://github.com/conda-forge/pytest-selenium-feedstock.git
+	branch = refs/heads/master
 [submodule "transaction"]
 	path = feedstocks/transaction
 	url = https://github.com/conda-forge/transaction-feedstock.git
+	branch = refs/heads/master
 [submodule "zodb"]
 	path = feedstocks/zodb
 	url = https://github.com/conda-forge/zodb-feedstock.git
+	branch = refs/heads/master
 [submodule "ezodf"]
 	path = feedstocks/ezodf
 	url = https://github.com/conda-forge/ezodf-feedstock.git
+	branch = refs/heads/master
 [submodule "linear-tsv"]
 	path = feedstocks/linear-tsv
 	url = https://github.com/conda-forge/linear-tsv-feedstock.git
+	branch = refs/heads/master
 [submodule "python-casacore"]
 	path = feedstocks/python-casacore
 	url = https://github.com/conda-forge/python-casacore-feedstock.git
+	branch = refs/heads/master
 [submodule "trash-cli"]
 	path = feedstocks/trash-cli
 	url = https://github.com/conda-forge/trash-cli-feedstock.git
+	branch = refs/heads/master
 [submodule "zdaemon"]
 	path = feedstocks/zdaemon
 	url = https://github.com/conda-forge/zdaemon-feedstock.git
+	branch = refs/heads/master
 [submodule "zeo"]
 	path = feedstocks/zeo
 	url = https://github.com/conda-forge/zeo-feedstock.git
+	branch = refs/heads/master
 [submodule "cchardet"]
 	path = feedstocks/cchardet
 	url = https://github.com/conda-forge/cchardet-feedstock.git
+	branch = refs/heads/master
 [submodule "jsonlines"]
 	path = feedstocks/jsonlines
 	url = https://github.com/conda-forge/jsonlines-feedstock.git
+	branch = refs/heads/master
 [submodule "winpty"]
 	path = feedstocks/winpty
 	url = https://github.com/conda-forge/winpty-feedstock.git
+	branch = refs/heads/master
 [submodule "clickclick"]
 	path = feedstocks/clickclick
 	url = https://github.com/conda-forge/clickclick-feedstock.git
+	branch = refs/heads/master
 [submodule "lorem"]
 	path = feedstocks/lorem
 	url = https://github.com/conda-forge/lorem-feedstock.git
+	branch = refs/heads/master
 [submodule "swagger-spec-validator"]
 	path = feedstocks/swagger-spec-validator
 	url = https://github.com/conda-forge/swagger-spec-validator-feedstock.git
+	branch = refs/heads/master
 [submodule "connexion"]
 	path = feedstocks/connexion
 	url = https://github.com/conda-forge/connexion-feedstock.git
+	branch = refs/heads/master
 [submodule "paramz"]
 	path = feedstocks/paramz
 	url = https://github.com/conda-forge/paramz-feedstock.git
+	branch = refs/heads/master
 [submodule "pyvirtualdisplay"]
 	path = feedstocks/pyvirtualdisplay
 	url = https://github.com/conda-forge/pyvirtualdisplay-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-ndmorph"]
 	path = feedstocks/dask-ndmorph
 	url = https://github.com/conda-forge/dask-ndmorph-feedstock.git
+	branch = refs/heads/master
 [submodule "gpy"]
 	path = feedstocks/gpy
 	url = https://github.com/conda-forge/gpy-feedstock.git
+	branch = refs/heads/master
 [submodule "datapackage-py"]
 	path = feedstocks/datapackage-py
 	url = https://github.com/conda-forge/datapackage-py-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-jsonpify"]
 	path = feedstocks/flask-jsonpify
 	url = https://github.com/conda-forge/flask-jsonpify-feedstock.git
+	branch = refs/heads/master
 [submodule "jsontableschema"]
 	path = feedstocks/jsontableschema
 	url = https://github.com/conda-forge/jsontableschema-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_qtconsole_colorschemes"]
 	path = feedstocks/jupyter_qtconsole_colorschemes
 	url = https://github.com/conda-forge/jupyter_qtconsole_colorschemes-feedstock.git
+	branch = refs/heads/master
 [submodule "prompt"]
 	path = feedstocks/prompt
 	url = https://github.com/conda-forge/prompt-feedstock.git
+	branch = refs/heads/master
 [submodule "pylama"]
 	path = feedstocks/pylama
 	url = https://github.com/conda-forge/pylama-feedstock.git
+	branch = refs/heads/master
 [submodule "tabulator-py"]
 	path = feedstocks/tabulator-py
 	url = https://github.com/conda-forge/tabulator-py-feedstock.git
+	branch = refs/heads/master
 [submodule "octave"]
 	path = feedstocks/octave
 	url = https://github.com/conda-forge/octave-feedstock.git
+	branch = refs/heads/master
 [submodule "pycoal"]
 	path = feedstocks/pycoal
 	url = https://github.com/conda-forge/pycoal-feedstock.git
+	branch = refs/heads/master
 [submodule "spectral"]
 	path = feedstocks/spectral
 	url = https://github.com/conda-forge/spectral-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-imread"]
 	path = feedstocks/dask-imread
 	url = https://github.com/conda-forge/dask-imread-feedstock.git
+	branch = refs/heads/master
 [submodule "datadotworld-py"]
 	path = feedstocks/datadotworld-py
 	url = https://github.com/conda-forge/datadotworld-py-feedstock.git
+	branch = refs/heads/master
 [submodule "ds-lime"]
 	path = feedstocks/ds-lime
 	url = https://github.com/conda-forge/ds-lime-feedstock.git
+	branch = refs/heads/master
 [submodule "jsontableschema-pandas"]
 	path = feedstocks/jsontableschema-pandas
 	url = https://github.com/conda-forge/jsontableschema-pandas-feedstock.git
+	branch = refs/heads/master
 [submodule "python-language-server"]
 	path = feedstocks/python-language-server
 	url = https://github.com/conda-forge/python-language-server-feedstock.git
+	branch = refs/heads/master
 [submodule "tableschema-py"]
 	path = feedstocks/tableschema-py
 	url = https://github.com/conda-forge/tableschema-py-feedstock.git
+	branch = refs/heads/master
 [submodule "wmctrl"]
 	path = feedstocks/wmctrl
 	url = https://github.com/conda-forge/wmctrl-feedstock.git
+	branch = refs/heads/master
 [submodule "pandas-compat"]
 	path = feedstocks/pandas-compat
 	url = https://github.com/conda-forge/pandas-compat-feedstock.git
+	branch = refs/heads/master
 [submodule "astunparse"]
 	path = feedstocks/astunparse
 	url = https://github.com/conda-forge/astunparse-feedstock.git
+	branch = refs/heads/master
 [submodule "elektronn2"]
 	path = feedstocks/elektronn2
 	url = https://github.com/conda-forge/elektronn2-feedstock.git
+	branch = refs/heads/master
 [submodule "google-auth"]
 	path = feedstocks/google-auth
 	url = https://github.com/conda-forge/google-auth-feedstock.git
+	branch = refs/heads/master
 [submodule "micromagneticmodel"]
 	path = feedstocks/micromagneticmodel
 	url = https://github.com/conda-forge/micromagneticmodel-feedstock.git
+	branch = refs/heads/master
 [submodule "odvc"]
 	path = feedstocks/odvc
 	url = https://github.com/conda-forge/odvc-feedstock.git
+	branch = refs/heads/master
 [submodule "pgcli"]
 	path = feedstocks/pgcli
 	url = https://github.com/conda-forge/pgcli-feedstock.git
+	branch = refs/heads/master
 [submodule "pgspecial"]
 	path = feedstocks/pgspecial
 	url = https://github.com/conda-forge/pgspecial-feedstock.git
+	branch = refs/heads/master
 [submodule "billingegroup"]
 	path = feedstocks/billingegroup
 	url = https://github.com/conda-forge/billingegroup-feedstock.git
+	branch = refs/heads/master
 [submodule "libidn11"]
 	path = feedstocks/libidn11
 	url = https://github.com/conda-forge/libidn11-feedstock.git
+	branch = refs/heads/master
 [submodule "lynx"]
 	path = feedstocks/lynx
 	url = https://github.com/conda-forge/lynx-feedstock.git
+	branch = refs/heads/master
 [submodule "skater"]
 	path = feedstocks/skater
 	url = https://github.com/conda-forge/skater-feedstock.git
+	branch = refs/heads/master
 [submodule "strict-rfc3339"]
 	path = feedstocks/strict-rfc3339
 	url = https://github.com/conda-forge/strict-rfc3339-feedstock.git
+	branch = refs/heads/master
 [submodule "svg2png"]
 	path = feedstocks/svg2png
 	url = https://github.com/conda-forge/svg2png-feedstock.git
+	branch = refs/heads/master
 [submodule "yappi"]
 	path = feedstocks/yappi
 	url = https://github.com/conda-forge/yappi-feedstock.git
+	branch = refs/heads/master
 [submodule "bkcharts"]
 	path = feedstocks/bkcharts
 	url = https://github.com/conda-forge/bkcharts-feedstock.git
+	branch = refs/heads/master
 [submodule "ccache-toolchain"]
 	path = feedstocks/ccache-toolchain
 	url = https://github.com/conda-forge/ccache-toolchain-feedstock.git
+	branch = refs/heads/master
 [submodule "google-auth-httplib2"]
 	path = feedstocks/google-auth-httplib2
 	url = https://github.com/conda-forge/google-auth-httplib2-feedstock.git
+	branch = refs/heads/master
 [submodule "google-auth-oauthlib"]
 	path = feedstocks/google-auth-oauthlib
 	url = https://github.com/conda-forge/google-auth-oauthlib-feedstock.git
+	branch = refs/heads/master
 [submodule "gridded"]
 	path = feedstocks/gridded
 	url = https://github.com/conda-forge/gridded-feedstock.git
+	branch = refs/heads/master
 [submodule "imread"]
 	path = feedstocks/imread
 	url = https://github.com/conda-forge/imread-feedstock.git
+	branch = refs/heads/master
 [submodule "odfpy"]
 	path = feedstocks/odfpy
 	url = https://github.com/conda-forge/odfpy-feedstock.git
+	branch = refs/heads/master
 [submodule "cram"]
 	path = feedstocks/cram
 	url = https://github.com/conda-forge/cram-feedstock.git
+	branch = refs/heads/master
 [submodule "hdf5storage"]
 	path = feedstocks/hdf5storage
 	url = https://github.com/conda-forge/hdf5storage-feedstock.git
+	branch = refs/heads/master
 [submodule "time"]
 	path = feedstocks/time
 	url = https://github.com/conda-forge/time-feedstock.git
+	branch = refs/heads/master
 [submodule "asn1crypto"]
 	path = feedstocks/asn1crypto
 	url = https://github.com/conda-forge/asn1crypto-feedstock.git
+	branch = refs/heads/master
 [submodule "fastcache"]
 	path = feedstocks/fastcache
 	url = https://github.com/conda-forge/fastcache-feedstock.git
+	branch = refs/heads/master
 [submodule "filterpy"]
 	path = feedstocks/filterpy
 	url = https://github.com/conda-forge/filterpy-feedstock.git
+	branch = refs/heads/master
 [submodule "google-cloud-core"]
 	path = feedstocks/google-cloud-core
 	url = https://github.com/conda-forge/google-cloud-core-feedstock.git
+	branch = refs/heads/master
 [submodule "googleapis-common-protos"]
 	path = feedstocks/googleapis-common-protos
 	url = https://github.com/conda-forge/googleapis-common-protos-feedstock.git
+	branch = refs/heads/master
 [submodule "hyperspy-gui-ipywidgets"]
 	path = feedstocks/hyperspy-gui-ipywidgets
 	url = https://github.com/conda-forge/hyperspy-gui-ipywidgets-feedstock.git
+	branch = refs/heads/master
 [submodule "hyperspy-gui-traitsui"]
 	path = feedstocks/hyperspy-gui-traitsui
 	url = https://github.com/conda-forge/hyperspy-gui-traitsui-feedstock.git
+	branch = refs/heads/master
 [submodule "libgdal"]
 	path = feedstocks/libgdal
 	url = https://github.com/conda-forge/libgdal-feedstock.git
+	branch = refs/heads/master
 [submodule "neo4j-python-driver"]
 	path = feedstocks/neo4j-python-driver
 	url = https://github.com/conda-forge/neo4j-python-driver-feedstock.git
+	branch = refs/heads/master
 [submodule "py2neo"]
 	path = feedstocks/py2neo
 	url = https://github.com/conda-forge/py2neo-feedstock.git
+	branch = refs/heads/master
 [submodule "tachyon"]
 	path = feedstocks/tachyon
 	url = https://github.com/conda-forge/tachyon-feedstock.git
+	branch = refs/heads/master
 [submodule "the_silver_searcher"]
 	path = feedstocks/the_silver_searcher
 	url = https://github.com/conda-forge/the_silver_searcher-feedstock.git
+	branch = refs/heads/master
 [submodule "xarray-simlab"]
 	path = feedstocks/xarray-simlab
 	url = https://github.com/conda-forge/xarray-simlab-feedstock.git
+	branch = refs/heads/master
 [submodule "django-material"]
 	path = feedstocks/django-material
 	url = https://github.com/conda-forge/django-material-feedstock.git
+	branch = refs/heads/master
 [submodule "django-viewflow"]
 	path = feedstocks/django-viewflow
 	url = https://github.com/conda-forge/django-viewflow-feedstock.git
+	branch = refs/heads/master
 [submodule "pygpu"]
 	path = feedstocks/pygpu
 	url = https://github.com/conda-forge/pygpu-feedstock.git
+	branch = refs/heads/master
 [submodule "toolchain3"]
 	path = feedstocks/toolchain3
 	url = https://github.com/conda-forge/toolchain3-feedstock.git
+	branch = refs/heads/master
 [submodule "xarray-topo"]
 	path = feedstocks/xarray-topo
 	url = https://github.com/conda-forge/xarray-topo-feedstock.git
+	branch = refs/heads/master
 [submodule "orca"]
 	path = feedstocks/orca
 	url = https://github.com/conda-forge/orca-feedstock.git
+	branch = refs/heads/master
 [submodule "freetds"]
 	path = feedstocks/freetds
 	url = https://github.com/conda-forge/freetds-feedstock.git
+	branch = refs/heads/master
 [submodule "google-cloud-storage"]
 	path = feedstocks/google-cloud-storage
 	url = https://github.com/conda-forge/google-cloud-storage-feedstock.git
+	branch = refs/heads/master
 [submodule "google-resumable-media"]
 	path = feedstocks/google-resumable-media
 	url = https://github.com/conda-forge/google-resumable-media-feedstock.git
+	branch = refs/heads/master
 [submodule "cryptography"]
 	path = feedstocks/cryptography
 	url = https://github.com/conda-forge/cryptography-feedstock.git
+	branch = refs/heads/master
 [submodule "django-guardian"]
 	path = feedstocks/django-guardian
 	url = https://github.com/conda-forge/django-guardian-feedstock.git
+	branch = refs/heads/master
 [submodule "phantomjs"]
 	path = feedstocks/phantomjs
 	url = https://github.com/conda-forge/phantomjs-feedstock.git
+	branch = refs/heads/master
 [submodule "reikna"]
 	path = feedstocks/reikna
 	url = https://github.com/conda-forge/reikna-feedstock.git
+	branch = refs/heads/master
 [submodule "tetgen"]
 	path = feedstocks/tetgen
 	url = https://github.com/conda-forge/tetgen-feedstock.git
+	branch = refs/heads/master
 [submodule "wxpython"]
 	path = feedstocks/wxpython
 	url = https://github.com/conda-forge/wxpython-feedstock.git
+	branch = refs/heads/master
 [submodule "pygobject"]
 	path = feedstocks/pygobject
 	url = https://github.com/conda-forge/pygobject-feedstock.git
+	branch = refs/heads/master
 [submodule "pytzdata"]
 	path = feedstocks/pytzdata
 	url = https://github.com/conda-forge/pytzdata-feedstock.git
+	branch = refs/heads/master
 [submodule "slycot"]
 	path = feedstocks/slycot
 	url = https://github.com/conda-forge/slycot-feedstock.git
+	branch = refs/heads/master
 [submodule "google-cloud-bigquery"]
 	path = feedstocks/google-cloud-bigquery
 	url = https://github.com/conda-forge/google-cloud-bigquery-feedstock.git
+	branch = refs/heads/master
 [submodule "google-cloud-monitoring"]
 	path = feedstocks/google-cloud-monitoring
 	url = https://github.com/conda-forge/google-cloud-monitoring-feedstock.git
+	branch = refs/heads/master
 [submodule "pendulum"]
 	path = feedstocks/pendulum
 	url = https://github.com/conda-forge/pendulum-feedstock.git
+	branch = refs/heads/master
 [submodule "control"]
 	path = feedstocks/control
 	url = https://github.com/conda-forge/control-feedstock.git
+	branch = refs/heads/master
 [submodule "diffpy.utils"]
 	path = feedstocks/diffpy.utils
 	url = https://github.com/conda-forge/diffpy.utils-feedstock.git
+	branch = refs/heads/master
 [submodule "automat"]
 	path = feedstocks/automat
 	url = https://github.com/conda-forge/automat-feedstock.git
+	branch = refs/heads/master
 [submodule "backports.weakref"]
 	path = feedstocks/backports.weakref
 	url = https://github.com/conda-forge/backports.weakref-feedstock.git
+	branch = refs/heads/master
 [submodule "clblas"]
 	path = feedstocks/clblas
 	url = https://github.com/conda-forge/clblas-feedstock.git
+	branch = refs/heads/master
 [submodule "clblast"]
 	path = feedstocks/clblast
 	url = https://github.com/conda-forge/clblast-feedstock.git
+	branch = refs/heads/master
 [submodule "tini"]
 	path = feedstocks/tini
 	url = https://github.com/conda-forge/tini-feedstock.git
+	branch = refs/heads/master
 [submodule "clfft"]
 	path = feedstocks/clfft
 	url = https://github.com/conda-forge/clfft-feedstock.git
+	branch = refs/heads/master
 [submodule "django-redis"]
 	path = feedstocks/django-redis
 	url = https://github.com/conda-forge/django-redis-feedstock.git
+	branch = refs/heads/master
 [submodule "uritools"]
 	path = feedstocks/uritools
 	url = https://github.com/conda-forge/uritools-feedstock.git
+	branch = refs/heads/master
 [submodule "django-pyodbc-azure"]
 	path = feedstocks/django-pyodbc-azure
 	url = https://github.com/conda-forge/django-pyodbc-azure-feedstock.git
+	branch = refs/heads/master
 [submodule "frozendict"]
 	path = feedstocks/frozendict
 	url = https://github.com/conda-forge/frozendict-feedstock.git
+	branch = refs/heads/master
 [submodule "rever"]
 	path = feedstocks/rever
 	url = https://github.com/conda-forge/rever-feedstock.git
+	branch = refs/heads/master
 [submodule "rsgislib"]
 	path = feedstocks/rsgislib
 	url = https://github.com/conda-forge/rsgislib-feedstock.git
+	branch = refs/heads/master
 [submodule "aldjemy"]
 	path = feedstocks/aldjemy
 	url = https://github.com/conda-forge/aldjemy-feedstock.git
+	branch = refs/heads/master
 [submodule "plumpy"]
 	path = feedstocks/plumpy
 	url = https://github.com/conda-forge/plumpy-feedstock.git
+	branch = refs/heads/master
 [submodule "libkml"]
 	path = feedstocks/libkml
 	url = https://github.com/conda-forge/libkml-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bookdown"]
 	path = feedstocks/r-bookdown
 	url = https://github.com/conda-forge/r-bookdown-feedstock.git
+	branch = refs/heads/master
 [submodule "c-progressbar"]
 	path = feedstocks/c-progressbar
 	url = https://github.com/conda-forge/c-progressbar-feedstock.git
+	branch = refs/heads/master
 [submodule "cbsyst"]
 	path = feedstocks/cbsyst
 	url = https://github.com/conda-forge/cbsyst-feedstock.git
+	branch = refs/heads/master
 [submodule "reentry"]
 	path = feedstocks/reentry
 	url = https://github.com/conda-forge/reentry-feedstock.git
+	branch = refs/heads/master
 [submodule "arcsi"]
 	path = feedstocks/arcsi
 	url = https://github.com/conda-forge/arcsi-feedstock.git
+	branch = refs/heads/master
 [submodule "dicttoxml"]
 	path = feedstocks/dicttoxml
 	url = https://github.com/conda-forge/dicttoxml-feedstock.git
+	branch = refs/heads/master
 [submodule "moto"]
 	path = feedstocks/moto
 	url = https://github.com/conda-forge/moto-feedstock.git
+	branch = refs/heads/master
 [submodule "python-kubernetes"]
 	path = feedstocks/python-kubernetes
 	url = https://github.com/conda-forge/python-kubernetes-feedstock.git
+	branch = refs/heads/master
 [submodule "pygmo_plugins_nonfree"]
 	path = feedstocks/pygmo_plugins_nonfree
 	url = https://github.com/conda-forge/pygmo_plugins_nonfree-feedstock.git
+	branch = refs/heads/master
 [submodule "pywinpty"]
 	path = feedstocks/pywinpty
 	url = https://github.com/conda-forge/pywinpty-feedstock.git
+	branch = refs/heads/master
 [submodule "r-plumber"]
 	path = feedstocks/r-plumber
 	url = https://github.com/conda-forge/r-plumber-feedstock.git
+	branch = refs/heads/master
 [submodule "ruby"]
 	path = feedstocks/ruby
 	url = https://github.com/conda-forge/ruby-feedstock.git
+	branch = refs/heads/master
 [submodule "larray_eurostat"]
 	path = feedstocks/larray_eurostat
 	url = https://github.com/conda-forge/larray_eurostat-feedstock.git
+	branch = refs/heads/master
 [submodule "larrayenv"]
 	path = feedstocks/larrayenv
 	url = https://github.com/conda-forge/larrayenv-feedstock.git
+	branch = refs/heads/master
 [submodule "clhpp"]
 	path = feedstocks/clhpp
 	url = https://github.com/conda-forge/clhpp-feedstock.git
+	branch = refs/heads/master
 [submodule "ctags"]
 	path = feedstocks/ctags
 	url = https://github.com/conda-forge/ctags-feedstock.git
+	branch = refs/heads/master
 [submodule "pymapd"]
 	path = feedstocks/pymapd
 	url = https://github.com/conda-forge/pymapd-feedstock.git
+	branch = refs/heads/master
 [submodule "pymbar"]
 	path = feedstocks/pymbar
 	url = https://github.com/conda-forge/pymbar-feedstock.git
+	branch = refs/heads/master
 [submodule "r-suppdists"]
 	path = feedstocks/r-suppdists
 	url = https://github.com/conda-forge/r-suppdists-feedstock.git
+	branch = refs/heads/master
 [submodule "clrng"]
 	path = feedstocks/clrng
 	url = https://github.com/conda-forge/clrng-feedstock.git
+	branch = refs/heads/master
 [submodule "clsparse"]
 	path = feedstocks/clsparse
 	url = https://github.com/conda-forge/clsparse-feedstock.git
+	branch = refs/heads/master
 [submodule "ldap3"]
 	path = feedstocks/ldap3
 	url = https://github.com/conda-forge/ldap3-feedstock.git
+	branch = refs/heads/master
 [submodule "numpy_groupies"]
 	path = feedstocks/numpy_groupies
 	url = https://github.com/conda-forge/numpy_groupies-feedstock.git
+	branch = refs/heads/master
 [submodule "osmnet"]
 	path = feedstocks/osmnet
 	url = https://github.com/conda-forge/osmnet-feedstock.git
+	branch = refs/heads/master
 [submodule "pmw"]
 	path = feedstocks/pmw
 	url = https://github.com/conda-forge/pmw-feedstock.git
+	branch = refs/heads/master
 [submodule "reportlab"]
 	path = feedstocks/reportlab
 	url = https://github.com/conda-forge/reportlab-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-procrustes"]
 	path = feedstocks/scikit-procrustes
 	url = https://github.com/conda-forge/scikit-procrustes-feedstock.git
+	branch = refs/heads/master
 [submodule "lastools"]
 	path = feedstocks/lastools
 	url = https://github.com/conda-forge/lastools-feedstock.git
+	branch = refs/heads/master
 [submodule "neomodel"]
 	path = feedstocks/neomodel
 	url = https://github.com/conda-forge/neomodel-feedstock.git
+	branch = refs/heads/master
 [submodule "pulsewaves"]
 	path = feedstocks/pulsewaves
 	url = https://github.com/conda-forge/pulsewaves-feedstock.git
+	branch = refs/heads/master
 [submodule "seapy"]
 	path = feedstocks/seapy
 	url = https://github.com/conda-forge/seapy-feedstock.git
+	branch = refs/heads/master
 [submodule "r-abind"]
 	path = feedstocks/r-abind
 	url = https://github.com/conda-forge/r-abind-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-data"]
 	path = feedstocks/scikit-data
 	url = https://github.com/conda-forge/scikit-data-feedstock.git
+	branch = refs/heads/master
 [submodule "bgen"]
 	path = feedstocks/bgen
 	url = https://github.com/conda-forge/bgen-feedstock.git
+	branch = refs/heads/master
 [submodule "paraview"]
 	path = feedstocks/paraview
 	url = https://github.com/conda-forge/paraview-feedstock.git
+	branch = refs/heads/master
 [submodule "autodocsumm"]
 	path = feedstocks/autodocsumm
 	url = https://github.com/conda-forge/autodocsumm-feedstock.git
+	branch = refs/heads/master
 [submodule "funcargparse"]
 	path = feedstocks/funcargparse
 	url = https://github.com/conda-forge/funcargparse-feedstock.git
+	branch = refs/heads/master
 [submodule "geoip"]
 	path = feedstocks/geoip
 	url = https://github.com/conda-forge/geoip-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mhsmm"]
 	path = feedstocks/r-mhsmm
 	url = https://github.com/conda-forge/r-mhsmm-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx-nbexamples"]
 	path = feedstocks/sphinx-nbexamples
 	url = https://github.com/conda-forge/sphinx-nbexamples-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-celery-helper"]
 	path = feedstocks/flask-celery-helper
 	url = https://github.com/conda-forge/flask-celery-helper-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-redis-helper"]
 	path = feedstocks/flask-redis-helper
 	url = https://github.com/conda-forge/flask-redis-helper-feedstock.git
+	branch = refs/heads/master
 [submodule "pigz"]
 	path = feedstocks/pigz
 	url = https://github.com/conda-forge/pigz-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-flask"]
 	path = feedstocks/pytest-flask
 	url = https://github.com/conda-forge/pytest-flask-feedstock.git
+	branch = refs/heads/master
 [submodule "r-callr"]
 	path = feedstocks/r-callr
 	url = https://github.com/conda-forge/r-callr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-covr"]
 	path = feedstocks/r-covr
 	url = https://github.com/conda-forge/r-covr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-flux"]
 	path = feedstocks/r-flux
 	url = https://github.com/conda-forge/r-flux-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggsci"]
 	path = feedstocks/r-ggsci
 	url = https://github.com/conda-forge/r-ggsci-feedstock.git
+	branch = refs/heads/master
 [submodule "superlance"]
 	path = feedstocks/superlance
 	url = https://github.com/conda-forge/superlance-feedstock.git
+	branch = refs/heads/master
 [submodule "xlwings"]
 	path = feedstocks/xlwings
 	url = https://github.com/conda-forge/xlwings-feedstock.git
+	branch = refs/heads/master
 [submodule "holopy"]
 	path = feedstocks/holopy
 	url = https://github.com/conda-forge/holopy-feedstock.git
+	branch = refs/heads/master
 [submodule "bazel"]
 	path = feedstocks/bazel
 	url = https://github.com/conda-forge/bazel-feedstock.git
+	branch = refs/heads/master
 [submodule "descarteslabs"]
 	path = feedstocks/descarteslabs
 	url = https://github.com/conda-forge/descarteslabs-feedstock.git
+	branch = refs/heads/master
 [submodule "magics"]
 	path = feedstocks/magics
 	url = https://github.com/conda-forge/magics-feedstock.git
+	branch = refs/heads/master
 [submodule "mpl_sample_data"]
 	path = feedstocks/mpl_sample_data
 	url = https://github.com/conda-forge/mpl_sample_data-feedstock.git
+	branch = refs/heads/master
 [submodule "openmp"]
 	path = feedstocks/openmp
 	url = https://github.com/conda-forge/openmp-feedstock.git
+	branch = refs/heads/master
 [submodule "rust"]
 	path = feedstocks/rust
 	url = https://github.com/conda-forge/rust-feedstock.git
+	branch = refs/heads/master
 [submodule "soappy"]
 	path = feedstocks/soappy
 	url = https://github.com/conda-forge/soappy-feedstock.git
+	branch = refs/heads/master
 [submodule "wstools"]
 	path = feedstocks/wstools
 	url = https://github.com/conda-forge/wstools-feedstock.git
+	branch = refs/heads/master
 [submodule "dirent"]
 	path = feedstocks/dirent
 	url = https://github.com/conda-forge/dirent-feedstock.git
+	branch = refs/heads/master
 [submodule "gshhg-gmt"]
 	path = feedstocks/gshhg-gmt
 	url = https://github.com/conda-forge/gshhg-gmt-feedstock.git
+	branch = refs/heads/master
 [submodule "iapws"]
 	path = feedstocks/iapws
 	url = https://github.com/conda-forge/iapws-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_full_width"]
 	path = feedstocks/jupyter_full_width
 	url = https://github.com/conda-forge/jupyter_full_width-feedstock.git
+	branch = refs/heads/master
 [submodule "nipy"]
 	path = feedstocks/nipy
 	url = https://github.com/conda-forge/nipy-feedstock.git
+	branch = refs/heads/master
 [submodule "oq-engine"]
 	path = feedstocks/oq-engine
 	url = https://github.com/conda-forge/oq-engine-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fnn"]
 	path = feedstocks/r-fnn
 	url = https://github.com/conda-forge/r-fnn-feedstock.git
+	branch = refs/heads/master
 [submodule "r-intervals"]
 	path = feedstocks/r-intervals
 	url = https://github.com/conda-forge/r-intervals-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-dsp-comm"]
 	path = feedstocks/scikit-dsp-comm
 	url = https://github.com/conda-forge/scikit-dsp-comm-feedstock.git
+	branch = refs/heads/master
 [submodule "simplejson"]
 	path = feedstocks/simplejson
 	url = https://github.com/conda-forge/simplejson-feedstock.git
+	branch = refs/heads/master
 [submodule "libitk"]
 	path = feedstocks/libitk
 	url = https://github.com/conda-forge/libitk-feedstock.git
+	branch = refs/heads/master
 [submodule "murphy"]
 	path = feedstocks/murphy
 	url = https://github.com/conda-forge/murphy-feedstock.git
+	branch = refs/heads/master
 [submodule "opt_einsum"]
 	path = feedstocks/opt_einsum
 	url = https://github.com/conda-forge/opt_einsum-feedstock.git
+	branch = refs/heads/master
 [submodule "poster"]
 	path = feedstocks/poster
 	url = https://github.com/conda-forge/poster-feedstock.git
+	branch = refs/heads/master
 [submodule "pyhrf"]
 	path = feedstocks/pyhrf
 	url = https://github.com/conda-forge/pyhrf-feedstock.git
+	branch = refs/heads/master
 [submodule "quantlab_launcher"]
 	path = feedstocks/quantlab_launcher
 	url = https://github.com/conda-forge/quantlab_launcher-feedstock.git
+	branch = refs/heads/master
 [submodule "catzzz"]
 	path = feedstocks/catzzz
 	url = https://github.com/conda-forge/catzzz-feedstock.git
+	branch = refs/heads/master
 [submodule "morfessor"]
 	path = feedstocks/morfessor
 	url = https://github.com/conda-forge/morfessor-feedstock.git
+	branch = refs/heads/master
 [submodule "retriever"]
 	path = feedstocks/retriever
 	url = https://github.com/conda-forge/retriever-feedstock.git
+	branch = refs/heads/master
 [submodule "travis-encrypt"]
 	path = feedstocks/travis-encrypt
 	url = https://github.com/conda-forge/travis-encrypt-feedstock.git
+	branch = refs/heads/master
 [submodule "wrighttools"]
 	path = feedstocks/wrighttools
 	url = https://github.com/conda-forge/wrighttools-feedstock.git
+	branch = refs/heads/master
 [submodule "clamd"]
 	path = feedstocks/clamd
 	url = https://github.com/conda-forge/clamd-feedstock.git
+	branch = refs/heads/master
 [submodule "datashape"]
 	path = feedstocks/datashape
 	url = https://github.com/conda-forge/datashape-feedstock.git
+	branch = refs/heads/master
 [submodule "otpod"]
 	path = feedstocks/otpod
 	url = https://github.com/conda-forge/otpod-feedstock.git
+	branch = refs/heads/master
 [submodule "patch"]
 	path = feedstocks/patch
 	url = https://github.com/conda-forge/patch-feedstock.git
+	branch = refs/heads/master
 [submodule "pyperclip"]
 	path = feedstocks/pyperclip
 	url = https://github.com/conda-forge/pyperclip-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dotcall64"]
 	path = feedstocks/r-dotcall64
 	url = https://github.com/conda-forge/r-dotcall64-feedstock.git
+	branch = refs/heads/master
 [submodule "glmnet"]
 	path = feedstocks/glmnet
 	url = https://github.com/conda-forge/glmnet-feedstock.git
+	branch = refs/heads/master
 [submodule "vectormath"]
 	path = feedstocks/vectormath
 	url = https://github.com/conda-forge/vectormath-feedstock.git
+	branch = refs/heads/master
 [submodule "bitarray"]
 	path = feedstocks/bitarray
 	url = https://github.com/conda-forge/bitarray-feedstock.git
+	branch = refs/heads/master
 [submodule "dcw-gmt"]
 	path = feedstocks/dcw-gmt
 	url = https://github.com/conda-forge/dcw-gmt-feedstock.git
+	branch = refs/heads/master
 [submodule "gevent"]
 	path = feedstocks/gevent
 	url = https://github.com/conda-forge/gevent-feedstock.git
+	branch = refs/heads/master
 [submodule "perl-xml-parser"]
 	path = feedstocks/perl-xml-parser
 	url = https://github.com/conda-forge/perl-xml-parser-feedstock.git
+	branch = refs/heads/master
 [submodule "quantlab"]
 	path = feedstocks/quantlab
 	url = https://github.com/conda-forge/quantlab-feedstock.git
+	branch = refs/heads/master
 [submodule "r-circstats"]
 	path = feedstocks/r-circstats
 	url = https://github.com/conda-forge/r-circstats-feedstock.git
+	branch = refs/heads/master
 [submodule "r-distillery"]
 	path = feedstocks/r-distillery
 	url = https://github.com/conda-forge/r-distillery-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fastcluster"]
 	path = feedstocks/r-fastcluster
 	url = https://github.com/conda-forge/r-fastcluster-feedstock.git
+	branch = refs/heads/master
 [submodule "r-goftest"]
 	path = feedstocks/r-goftest
 	url = https://github.com/conda-forge/r-goftest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gstat"]
 	path = feedstocks/r-gstat
 	url = https://github.com/conda-forge/r-gstat-feedstock.git
+	branch = refs/heads/master
 [submodule "r-polyclip"]
 	path = feedstocks/r-polyclip
 	url = https://github.com/conda-forge/r-polyclip-feedstock.git
+	branch = refs/heads/master
 [submodule "r-spacetime"]
 	path = feedstocks/r-spacetime
 	url = https://github.com/conda-forge/r-spacetime-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tensor"]
 	path = feedstocks/r-tensor
 	url = https://github.com/conda-forge/r-tensor-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinx_bootstrap_theme"]
 	path = feedstocks/sphinx_bootstrap_theme
 	url = https://github.com/conda-forge/sphinx_bootstrap_theme-feedstock.git
+	branch = refs/heads/master
 [submodule "gcsfs"]
 	path = feedstocks/gcsfs
 	url = https://github.com/conda-forge/gcsfs-feedstock.git
+	branch = refs/heads/master
 [submodule "pot"]
 	path = feedstocks/pot
 	url = https://github.com/conda-forge/pot-feedstock.git
+	branch = refs/heads/master
 [submodule "lightgbm"]
 	path = feedstocks/lightgbm
 	url = https://github.com/conda-forge/lightgbm-feedstock.git
+	branch = refs/heads/master
 [submodule "odo"]
 	path = feedstocks/odo
 	url = https://github.com/conda-forge/odo-feedstock.git
+	branch = refs/heads/master
 [submodule "properties"]
 	path = feedstocks/properties
 	url = https://github.com/conda-forge/properties-feedstock.git
+	branch = refs/heads/master
 [submodule "shogun-cpp"]
 	path = feedstocks/shogun-cpp
 	url = https://github.com/conda-forge/shogun-cpp-feedstock.git
+	branch = refs/heads/master
 [submodule "shogun"]
 	path = feedstocks/shogun
 	url = https://github.com/conda-forge/shogun-feedstock.git
+	branch = refs/heads/master
 [submodule "cyflann"]
 	path = feedstocks/cyflann
 	url = https://github.com/conda-forge/cyflann-feedstock.git
+	branch = refs/heads/master
 [submodule "xlwt"]
 	path = feedstocks/xlwt
 	url = https://github.com/conda-forge/xlwt-feedstock.git
+	branch = refs/heads/master
 [submodule "astroscrappy"]
 	path = feedstocks/astroscrappy
 	url = https://github.com/conda-forge/astroscrappy-feedstock.git
+	branch = refs/heads/master
 [submodule "ctds"]
 	path = feedstocks/ctds
 	url = https://github.com/conda-forge/ctds-feedstock.git
+	branch = refs/heads/master
 [submodule "moviepy"]
 	path = feedstocks/moviepy
 	url = https://github.com/conda-forge/moviepy-feedstock.git
+	branch = refs/heads/master
 [submodule "silx"]
 	path = feedstocks/silx
 	url = https://github.com/conda-forge/silx-feedstock.git
+	branch = refs/heads/master
 [submodule "unicodecsv"]
 	path = feedstocks/unicodecsv
 	url = https://github.com/conda-forge/unicodecsv-feedstock.git
+	branch = refs/heads/master
 [submodule "ginga"]
 	path = feedstocks/ginga
 	url = https://github.com/conda-forge/ginga-feedstock.git
+	branch = refs/heads/master
 [submodule "purepng"]
 	path = feedstocks/purepng
 	url = https://github.com/conda-forge/purepng-feedstock.git
+	branch = refs/heads/master
 [submodule "aioeasywebdav"]
 	path = feedstocks/aioeasywebdav
 	url = https://github.com/conda-forge/aioeasywebdav-feedstock.git
+	branch = refs/heads/master
 [submodule "orderedmultidict"]
 	path = feedstocks/orderedmultidict
 	url = https://github.com/conda-forge/orderedmultidict-feedstock.git
+	branch = refs/heads/master
 [submodule "apipkg"]
 	path = feedstocks/apipkg
 	url = https://github.com/conda-forge/apipkg-feedstock.git
+	branch = refs/heads/master
 [submodule "execnet"]
 	path = feedstocks/execnet
 	url = https://github.com/conda-forge/execnet-feedstock.git
+	branch = refs/heads/master
 [submodule "furl"]
 	path = feedstocks/furl
 	url = https://github.com/conda-forge/furl-feedstock.git
+	branch = refs/heads/master
 [submodule "ipython_unittest"]
 	path = feedstocks/ipython_unittest
 	url = https://github.com/conda-forge/ipython_unittest-feedstock.git
+	branch = refs/heads/master
 [submodule "jupyter_dojo"]
 	path = feedstocks/jupyter_dojo
 	url = https://github.com/conda-forge/jupyter_dojo-feedstock.git
+	branch = refs/heads/master
 [submodule "r-diptest"]
 	path = feedstocks/r-diptest
 	url = https://github.com/conda-forge/r-diptest-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-optimize"]
 	path = feedstocks/scikit-optimize
 	url = https://github.com/conda-forge/scikit-optimize-feedstock.git
+	branch = refs/heads/master
 [submodule "xproperty"]
 	path = feedstocks/xproperty
 	url = https://github.com/conda-forge/xproperty-feedstock.git
+	branch = refs/heads/master
 [submodule "missingno"]
 	path = feedstocks/missingno
 	url = https://github.com/conda-forge/missingno-feedstock.git
+	branch = refs/heads/master
 [submodule "peakutils"]
 	path = feedstocks/peakutils
 	url = https://github.com/conda-forge/peakutils-feedstock.git
+	branch = refs/heads/master
 [submodule "python-libarchive-c"]
 	path = feedstocks/python-libarchive-c
 	url = https://github.com/conda-forge/python-libarchive-c-feedstock.git
+	branch = refs/heads/master
 [submodule "pymks"]
 	path = feedstocks/pymks
 	url = https://github.com/conda-forge/pymks-feedstock.git
+	branch = refs/heads/master
 [submodule "spectrum"]
 	path = feedstocks/spectrum
 	url = https://github.com/conda-forge/spectrum-feedstock.git
+	branch = refs/heads/master
 [submodule "jbig"]
 	path = feedstocks/jbig
 	url = https://github.com/conda-forge/jbig-feedstock.git
+	branch = refs/heads/master
 [submodule "python-lzo"]
 	path = feedstocks/python-lzo
 	url = https://github.com/conda-forge/python-lzo-feedstock.git
+	branch = refs/heads/master
 [submodule "pywim"]
 	path = feedstocks/pywim
 	url = https://github.com/conda-forge/pywim-feedstock.git
+	branch = refs/heads/master
 [submodule "r-beeswarm"]
 	path = feedstocks/r-beeswarm
 	url = https://github.com/conda-forge/r-beeswarm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-vipor"]
 	path = feedstocks/r-vipor
 	url = https://github.com/conda-forge/r-vipor-feedstock.git
+	branch = refs/heads/master
 [submodule "scikit-plot"]
 	path = feedstocks/scikit-plot
 	url = https://github.com/conda-forge/scikit-plot-feedstock.git
+	branch = refs/heads/master
 [submodule "biopython"]
 	path = feedstocks/biopython
 	url = https://github.com/conda-forge/biopython-feedstock.git
+	branch = refs/heads/master
 [submodule "eqcorrscan"]
 	path = feedstocks/eqcorrscan
 	url = https://github.com/conda-forge/eqcorrscan-feedstock.git
+	branch = refs/heads/master
 [submodule "mlxtend"]
 	path = feedstocks/mlxtend
 	url = https://github.com/conda-forge/mlxtend-feedstock.git
+	branch = refs/heads/master
 [submodule "python-oauth2"]
 	path = feedstocks/python-oauth2
 	url = https://github.com/conda-forge/python-oauth2-feedstock.git
+	branch = refs/heads/master
 [submodule "astro-gala"]
 	path = feedstocks/astro-gala
 	url = https://github.com/conda-forge/astro-gala-feedstock.git
+	branch = refs/heads/master
 [submodule "ccdproc"]
 	path = feedstocks/ccdproc
 	url = https://github.com/conda-forge/ccdproc-feedstock.git
+	branch = refs/heads/master
 [submodule "jsdom"]
 	path = feedstocks/jsdom
 	url = https://github.com/conda-forge/jsdom-feedstock.git
+	branch = refs/heads/master
 [submodule "photutils"]
 	path = feedstocks/photutils
 	url = https://github.com/conda-forge/photutils-feedstock.git
+	branch = refs/heads/master
 [submodule "pyserial"]
 	path = feedstocks/pyserial
 	url = https://github.com/conda-forge/pyserial-feedstock.git
+	branch = refs/heads/master
 [submodule "pyvo"]
 	path = feedstocks/pyvo
 	url = https://github.com/conda-forge/pyvo-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hoardr"]
 	path = feedstocks/r-hoardr
 	url = https://github.com/conda-forge/r-hoardr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rgdal"]
 	path = feedstocks/r-rgdal
 	url = https://github.com/conda-forge/r-rgdal-feedstock.git
+	branch = refs/heads/master
 [submodule "sparkmagic"]
 	path = feedstocks/sparkmagic
 	url = https://github.com/conda-forge/sparkmagic-feedstock.git
+	branch = refs/heads/master
 [submodule "autovizwidget"]
 	path = feedstocks/autovizwidget
 	url = https://github.com/conda-forge/autovizwidget-feedstock.git
+	branch = refs/heads/master
 [submodule "cdecimal"]
 	path = feedstocks/cdecimal
 	url = https://github.com/conda-forge/cdecimal-feedstock.git
+	branch = refs/heads/master
 [submodule "galpy"]
 	path = feedstocks/galpy
 	url = https://github.com/conda-forge/galpy-feedstock.git
+	branch = refs/heads/master
 [submodule "hdijupyterutils"]
 	path = feedstocks/hdijupyterutils
 	url = https://github.com/conda-forge/hdijupyterutils-feedstock.git
+	branch = refs/heads/master
 [submodule "pyodbc"]
 	path = feedstocks/pyodbc
 	url = https://github.com/conda-forge/pyodbc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-permute"]
 	path = feedstocks/r-permute
 	url = https://github.com/conda-forge/r-permute-feedstock.git
+	branch = refs/heads/master
 [submodule "aipy"]
 	path = feedstocks/aipy
 	url = https://github.com/conda-forge/aipy-feedstock.git
+	branch = refs/heads/master
 [submodule "aplpy"]
 	path = feedstocks/aplpy
 	url = https://github.com/conda-forge/aplpy-feedstock.git
+	branch = refs/heads/master
 [submodule "astroplan"]
 	path = feedstocks/astroplan
 	url = https://github.com/conda-forge/astroplan-feedstock.git
+	branch = refs/heads/master
 [submodule "diffoscope"]
 	path = feedstocks/diffoscope
 	url = https://github.com/conda-forge/diffoscope-feedstock.git
+	branch = refs/heads/master
 [submodule "exempi"]
 	path = feedstocks/exempi
 	url = https://github.com/conda-forge/exempi-feedstock.git
+	branch = refs/heads/master
 [submodule "orderedset"]
 	path = feedstocks/orderedset
 	url = https://github.com/conda-forge/orderedset-feedstock.git
+	branch = refs/heads/master
 [submodule "pdbpp"]
 	path = feedstocks/pdbpp
 	url = https://github.com/conda-forge/pdbpp-feedstock.git
+	branch = refs/heads/master
 [submodule "pdfminer3k"]
 	path = feedstocks/pdfminer3k
 	url = https://github.com/conda-forge/pdfminer3k-feedstock.git
+	branch = refs/heads/master
 [submodule "psy-maps"]
 	path = feedstocks/psy-maps
 	url = https://github.com/conda-forge/psy-maps-feedstock.git
+	branch = refs/heads/master
 [submodule "psy-reg"]
 	path = feedstocks/psy-reg
 	url = https://github.com/conda-forge/psy-reg-feedstock.git
+	branch = refs/heads/master
 [submodule "psy-simple"]
 	path = feedstocks/psy-simple
 	url = https://github.com/conda-forge/psy-simple-feedstock.git
+	branch = refs/heads/master
 [submodule "psyplot"]
 	path = feedstocks/psyplot
 	url = https://github.com/conda-forge/psyplot-feedstock.git
+	branch = refs/heads/master
 [submodule "psyplot-gui"]
 	path = feedstocks/psyplot-gui
 	url = https://github.com/conda-forge/psyplot-gui-feedstock.git
+	branch = refs/heads/master
 [submodule "pygments_anyscript"]
 	path = feedstocks/pygments_anyscript
 	url = https://github.com/conda-forge/pygments_anyscript-feedstock.git
+	branch = refs/heads/master
 [submodule "r-arm"]
 	path = feedstocks/r-arm
 	url = https://github.com/conda-forge/r-arm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-automap"]
 	path = feedstocks/r-automap
 	url = https://github.com/conda-forge/r-automap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-evd"]
 	path = feedstocks/r-evd
 	url = https://github.com/conda-forge/r-evd-feedstock.git
+	branch = refs/heads/master
 [submodule "r-vegan"]
 	path = feedstocks/r-vegan
 	url = https://github.com/conda-forge/r-vegan-feedstock.git
+	branch = refs/heads/master
 [submodule "setuptools_markdown"]
 	path = feedstocks/setuptools_markdown
 	url = https://github.com/conda-forge/setuptools_markdown-feedstock.git
+	branch = refs/heads/master
 [submodule "smmap2"]
 	path = feedstocks/smmap2
 	url = https://github.com/conda-forge/smmap2-feedstock.git
+	branch = refs/heads/master
 [submodule "spherical-geometry"]
 	path = feedstocks/spherical-geometry
 	url = https://github.com/conda-forge/spherical-geometry-feedstock.git
+	branch = refs/heads/master
 [submodule "spyder-notebook"]
 	path = feedstocks/spyder-notebook
 	url = https://github.com/conda-forge/spyder-notebook-feedstock.git
+	branch = refs/heads/master
 [submodule "trottersuzuki"]
 	path = feedstocks/trottersuzuki
 	url = https://github.com/conda-forge/trottersuzuki-feedstock.git
+	branch = refs/heads/master
 [submodule "web.py"]
 	path = feedstocks/web.py
 	url = https://github.com/conda-forge/web.py-feedstock.git
+	branch = refs/heads/master
 [submodule "alpenglow"]
 	path = feedstocks/alpenglow
 	url = https://github.com/conda-forge/alpenglow-feedstock.git
+	branch = refs/heads/master
 [submodule "anaconda-project"]
 	path = feedstocks/anaconda-project
 	url = https://github.com/conda-forge/anaconda-project-feedstock.git
+	branch = refs/heads/master
 [submodule "ansible"]
 	path = feedstocks/ansible
 	url = https://github.com/conda-forge/ansible-feedstock.git
+	branch = refs/heads/master
 [submodule "appscript"]
 	path = feedstocks/appscript
 	url = https://github.com/conda-forge/appscript-feedstock.git
+	branch = refs/heads/master
 [submodule "asdf"]
 	path = feedstocks/asdf
 	url = https://github.com/conda-forge/asdf-feedstock.git
+	branch = refs/heads/master
 [submodule "astroml"]
 	path = feedstocks/astroml
 	url = https://github.com/conda-forge/astroml-feedstock.git
+	branch = refs/heads/master
 [submodule "atk"]
 	path = feedstocks/atk
 	url = https://github.com/conda-forge/atk-feedstock.git
+	branch = refs/heads/master
 [submodule "beakerx"]
 	path = feedstocks/beakerx
 	url = https://github.com/conda-forge/beakerx-feedstock.git
+	branch = refs/heads/master
 [submodule "bfg"]
 	path = feedstocks/bfg
 	url = https://github.com/conda-forge/bfg-feedstock.git
+	branch = refs/heads/master
 [submodule "blaze"]
 	path = feedstocks/blaze
 	url = https://github.com/conda-forge/blaze-feedstock.git
+	branch = refs/heads/master
 [submodule "bootstrap_contrast"]
 	path = feedstocks/bootstrap_contrast
 	url = https://github.com/conda-forge/bootstrap_contrast-feedstock.git
+	branch = refs/heads/master
 [submodule "bson"]
 	path = feedstocks/bson
 	url = https://github.com/conda-forge/bson-feedstock.git
+	branch = refs/heads/master
 [submodule "cli_helpers"]
 	path = feedstocks/cli_helpers
 	url = https://github.com/conda-forge/cli_helpers-feedstock.git
+	branch = refs/heads/master
 [submodule "cluster-lensing"]
 	path = feedstocks/cluster-lensing
 	url = https://github.com/conda-forge/cluster-lensing-feedstock.git
+	branch = refs/heads/master
 [submodule "coconut"]
 	path = feedstocks/coconut
 	url = https://github.com/conda-forge/coconut-feedstock.git
+	branch = refs/heads/master
 [submodule "collectfast"]
 	path = feedstocks/collectfast
 	url = https://github.com/conda-forge/collectfast-feedstock.git
+	branch = refs/heads/master
 [submodule "colour"]
 	path = feedstocks/colour
 	url = https://github.com/conda-forge/colour-feedstock.git
+	branch = refs/heads/master
 [submodule "comtypes"]
 	path = feedstocks/comtypes
 	url = https://github.com/conda-forge/comtypes-feedstock.git
+	branch = refs/heads/master
 [submodule "constantly"]
 	path = feedstocks/constantly
 	url = https://github.com/conda-forge/constantly-feedstock.git
+	branch = refs/heads/master
 [submodule "containerpilot"]
 	path = feedstocks/containerpilot
 	url = https://github.com/conda-forge/containerpilot-feedstock.git
+	branch = refs/heads/master
 [submodule "cppcheck"]
 	path = feedstocks/cppcheck
 	url = https://github.com/conda-forge/cppcheck-feedstock.git
+	branch = refs/heads/master
 [submodule "cssmin"]
 	path = feedstocks/cssmin
 	url = https://github.com/conda-forge/cssmin-feedstock.git
+	branch = refs/heads/master
 [submodule "cxxopts"]
 	path = feedstocks/cxxopts
 	url = https://github.com/conda-forge/cxxopts-feedstock.git
+	branch = refs/heads/master
 [submodule "d2to1"]
 	path = feedstocks/d2to1
 	url = https://github.com/conda-forge/d2to1-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-core"]
 	path = feedstocks/dask-core
 	url = https://github.com/conda-forge/dask-core-feedstock.git
+	branch = refs/heads/master
 [submodule "dask-ndmeasure"]
 	path = feedstocks/dask-ndmeasure
 	url = https://github.com/conda-forge/dask-ndmeasure-feedstock.git
+	branch = refs/heads/master
 [submodule "decorator"]
 	path = feedstocks/decorator
 	url = https://github.com/conda-forge/decorator-feedstock.git
+	branch = refs/heads/master
 [submodule "deepgraph"]
 	path = feedstocks/deepgraph
 	url = https://github.com/conda-forge/deepgraph-feedstock.git
+	branch = refs/heads/master
 [submodule "deprecation"]
 	path = feedstocks/deprecation
 	url = https://github.com/conda-forge/deprecation-feedstock.git
+	branch = refs/heads/master
 [submodule "diffpy.structure"]
 	path = feedstocks/diffpy.structure
 	url = https://github.com/conda-forge/diffpy.structure-feedstock.git
+	branch = refs/heads/master
 [submodule "dj-database-url"]
 	path = feedstocks/dj-database-url
 	url = https://github.com/conda-forge/dj-database-url-feedstock.git
+	branch = refs/heads/master
 [submodule "django-allauth"]
 	path = feedstocks/django-allauth
 	url = https://github.com/conda-forge/django-allauth-feedstock.git
+	branch = refs/heads/master
 [submodule "django-anymail"]
 	path = feedstocks/django-anymail
 	url = https://github.com/conda-forge/django-anymail-feedstock.git
+	branch = refs/heads/master
 [submodule "django-appconf"]
 	path = feedstocks/django-appconf
 	url = https://github.com/conda-forge/django-appconf-feedstock.git
+	branch = refs/heads/master
 [submodule "django-bootstrap3"]
 	path = feedstocks/django-bootstrap3
 	url = https://github.com/conda-forge/django-bootstrap3-feedstock.git
+	branch = refs/heads/master
 [submodule "django-braces"]
 	path = feedstocks/django-braces
 	url = https://github.com/conda-forge/django-braces-feedstock.git
+	branch = refs/heads/master
 [submodule "django-cachalot"]
 	path = feedstocks/django-cachalot
 	url = https://github.com/conda-forge/django-cachalot-feedstock.git
+	branch = refs/heads/master
 [submodule "django-chunked-upload"]
 	path = feedstocks/django-chunked-upload
 	url = https://github.com/conda-forge/django-chunked-upload-feedstock.git
+	branch = refs/heads/master
 [submodule "django-configurations"]
 	path = feedstocks/django-configurations
 	url = https://github.com/conda-forge/django-configurations-feedstock.git
+	branch = refs/heads/master
 [submodule "django-crispy-forms"]
 	path = feedstocks/django-crispy-forms
 	url = https://github.com/conda-forge/django-crispy-forms-feedstock.git
+	branch = refs/heads/master
 [submodule "django-environ"]
 	path = feedstocks/django-environ
 	url = https://github.com/conda-forge/django-environ-feedstock.git
+	branch = refs/heads/master
 [submodule "django-foundation-formtags"]
 	path = feedstocks/django-foundation-formtags
 	url = https://github.com/conda-forge/django-foundation-formtags-feedstock.git
+	branch = refs/heads/master
 [submodule "django-fsm"]
 	path = feedstocks/django-fsm
 	url = https://github.com/conda-forge/django-fsm-feedstock.git
+	branch = refs/heads/master
 [submodule "django-leaflet"]
 	path = feedstocks/django-leaflet
 	url = https://github.com/conda-forge/django-leaflet-feedstock.git
+	branch = refs/heads/master
 [submodule "django-makemessages-xgettext"]
 	path = feedstocks/django-makemessages-xgettext
 	url = https://github.com/conda-forge/django-makemessages-xgettext-feedstock.git
+	branch = refs/heads/master
 [submodule "django-model-utils"]
 	path = feedstocks/django-model-utils
 	url = https://github.com/conda-forge/django-model-utils-feedstock.git
+	branch = refs/heads/master
 [submodule "django-modelcluster"]
 	path = feedstocks/django-modelcluster
 	url = https://github.com/conda-forge/django-modelcluster-feedstock.git
+	branch = refs/heads/master
 [submodule "django-storages"]
 	path = feedstocks/django-storages
 	url = https://github.com/conda-forge/django-storages-feedstock.git
+	branch = refs/heads/master
 [submodule "django-storages-redux"]
 	path = feedstocks/django-storages-redux
 	url = https://github.com/conda-forge/django-storages-redux-feedstock.git
+	branch = refs/heads/master
 [submodule "django-test-plus"]
 	path = feedstocks/django-test-plus
 	url = https://github.com/conda-forge/django-test-plus-feedstock.git
+	branch = refs/heads/master
 [submodule "django-treebeard"]
 	path = feedstocks/django-treebeard
 	url = https://github.com/conda-forge/django-treebeard-feedstock.git
+	branch = refs/heads/master
 [submodule "django-unique-upload"]
 	path = feedstocks/django-unique-upload
 	url = https://github.com/conda-forge/django-unique-upload-feedstock.git
+	branch = refs/heads/master
 [submodule "django-versatileimagefield"]
 	path = feedstocks/django-versatileimagefield
 	url = https://github.com/conda-forge/django-versatileimagefield-feedstock.git
+	branch = refs/heads/master
 [submodule "django_compressor"]
 	path = feedstocks/django_compressor
 	url = https://github.com/conda-forge/django_compressor-feedstock.git
+	branch = refs/heads/master
 [submodule "django_coverage_plugin"]
 	path = feedstocks/django_coverage_plugin
 	url = https://github.com/conda-forge/django_coverage_plugin-feedstock.git
+	branch = refs/heads/master
 [submodule "dnspython"]
 	path = feedstocks/dnspython
 	url = https://github.com/conda-forge/dnspython-feedstock.git
+	branch = refs/heads/master
 [submodule "dogpile.cache"]
 	path = feedstocks/dogpile.cache
 	url = https://github.com/conda-forge/dogpile.cache-feedstock.git
+	branch = refs/heads/master
 [submodule "dynamicisttoolkit"]
 	path = feedstocks/dynamicisttoolkit
 	url = https://github.com/conda-forge/dynamicisttoolkit-feedstock.git
+	branch = refs/heads/master
 [submodule "email_validator"]
 	path = feedstocks/email_validator
 	url = https://github.com/conda-forge/email_validator-feedstock.git
+	branch = refs/heads/master
 [submodule "empath"]
 	path = feedstocks/empath
 	url = https://github.com/conda-forge/empath-feedstock.git
+	branch = refs/heads/master
 [submodule "ez_setup"]
 	path = feedstocks/ez_setup
 	url = https://github.com/conda-forge/ez_setup-feedstock.git
+	branch = refs/heads/master
 [submodule "fast-histogram"]
 	path = feedstocks/fast-histogram
 	url = https://github.com/conda-forge/fast-histogram-feedstock.git
+	branch = refs/heads/master
 [submodule "fdupes"]
 	path = feedstocks/fdupes
 	url = https://github.com/conda-forge/fdupes-feedstock.git
+	branch = refs/heads/master
 [submodule "filesdb"]
 	path = feedstocks/filesdb
 	url = https://github.com/conda-forge/filesdb-feedstock.git
+	branch = refs/heads/master
 [submodule "flake8-blind-except"]
 	path = feedstocks/flake8-blind-except
 	url = https://github.com/conda-forge/flake8-blind-except-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-turbolinks"]
 	path = feedstocks/flask-turbolinks
 	url = https://github.com/conda-forge/flask-turbolinks-feedstock.git
+	branch = refs/heads/master
 [submodule "gammapy"]
 	path = feedstocks/gammapy
 	url = https://github.com/conda-forge/gammapy-feedstock.git
+	branch = refs/heads/master
 [submodule "gdk-pixbuf"]
 	path = feedstocks/gdk-pixbuf
 	url = https://github.com/conda-forge/gdk-pixbuf-feedstock.git
+	branch = refs/heads/master
 [submodule "gensim"]
 	path = feedstocks/gensim
 	url = https://github.com/conda-forge/gensim-feedstock.git
+	branch = refs/heads/master
 [submodule "gitdb2"]
 	path = feedstocks/gitdb2
 	url = https://github.com/conda-forge/gitdb2-feedstock.git
+	branch = refs/heads/master
 [submodule "graphene"]
 	path = feedstocks/graphene
 	url = https://github.com/conda-forge/graphene-feedstock.git
+	branch = refs/heads/master
 [submodule "graphql-core"]
 	path = feedstocks/graphql-core
 	url = https://github.com/conda-forge/graphql-core-feedstock.git
+	branch = refs/heads/master
 [submodule "graphql-relay"]
 	path = feedstocks/graphql-relay
 	url = https://github.com/conda-forge/graphql-relay-feedstock.git
+	branch = refs/heads/master
 [submodule "grin"]
 	path = feedstocks/grin
 	url = https://github.com/conda-forge/grin-feedstock.git
+	branch = refs/heads/master
 [submodule "gwcs"]
 	path = feedstocks/gwcs
 	url = https://github.com/conda-forge/gwcs-feedstock.git
+	branch = refs/heads/master
 [submodule "halotools"]
 	path = feedstocks/halotools
 	url = https://github.com/conda-forge/halotools-feedstock.git
+	branch = refs/heads/master
 [submodule "hunspell-en"]
 	path = feedstocks/hunspell-en
 	url = https://github.com/conda-forge/hunspell-en-feedstock.git
+	branch = refs/heads/master
 [submodule "hunspell"]
 	path = feedstocks/hunspell
 	url = https://github.com/conda-forge/hunspell-feedstock.git
+	branch = refs/heads/master
 [submodule "hyperlink"]
 	path = feedstocks/hyperlink
 	url = https://github.com/conda-forge/hyperlink-feedstock.git
+	branch = refs/heads/master
 [submodule "imagemagick"]
 	path = feedstocks/imagemagick
 	url = https://github.com/conda-forge/imagemagick-feedstock.git
+	branch = refs/heads/master
 [submodule "imexam"]
 	path = feedstocks/imexam
 	url = https://github.com/conda-forge/imexam-feedstock.git
+	branch = refs/heads/master
 [submodule "iminuit"]
 	path = feedstocks/iminuit
 	url = https://github.com/conda-forge/iminuit-feedstock.git
+	branch = refs/heads/master
 [submodule "incremental"]
 	path = feedstocks/incremental
 	url = https://github.com/conda-forge/incremental-feedstock.git
+	branch = refs/heads/master
 [submodule "infinity"]
 	path = feedstocks/infinity
 	url = https://github.com/conda-forge/infinity-feedstock.git
+	branch = refs/heads/master
 [submodule "interlap"]
 	path = feedstocks/interlap
 	url = https://github.com/conda-forge/interlap-feedstock.git
+	branch = refs/heads/master
 [submodule "intervals"]
 	path = feedstocks/intervals
 	url = https://github.com/conda-forge/intervals-feedstock.git
+	branch = refs/heads/master
 [submodule "intltool"]
 	path = feedstocks/intltool
 	url = https://github.com/conda-forge/intltool-feedstock.git
+	branch = refs/heads/master
 [submodule "ioos_tools"]
 	path = feedstocks/ioos_tools
 	url = https://github.com/conda-forge/ioos_tools-feedstock.git
+	branch = refs/heads/master
 [submodule "ipaddr"]
 	path = feedstocks/ipaddr
 	url = https://github.com/conda-forge/ipaddr-feedstock.git
+	branch = refs/heads/master
 [submodule "iperf"]
 	path = feedstocks/iperf
 	url = https://github.com/conda-forge/iperf-feedstock.git
+	branch = refs/heads/master
 [submodule "ipywebrtc"]
 	path = feedstocks/ipywebrtc
 	url = https://github.com/conda-forge/ipywebrtc-feedstock.git
+	branch = refs/heads/master
 [submodule "itk"]
 	path = feedstocks/itk
 	url = https://github.com/conda-forge/itk-feedstock.git
+	branch = refs/heads/master
 [submodule "jcc"]
 	path = feedstocks/jcc
 	url = https://github.com/conda-forge/jcc-feedstock.git
+	branch = refs/heads/master
 [submodule "jenkspy"]
 	path = feedstocks/jenkspy
 	url = https://github.com/conda-forge/jenkspy-feedstock.git
+	branch = refs/heads/master
 [submodule "jsonpickle"]
 	path = feedstocks/jsonpickle
 	url = https://github.com/conda-forge/jsonpickle-feedstock.git
+	branch = refs/heads/master
 [submodule "julia"]
 	path = feedstocks/julia
 	url = https://github.com/conda-forge/julia-feedstock.git
+	branch = refs/heads/master
 [submodule "knit"]
 	path = feedstocks/knit
 	url = https://github.com/conda-forge/knit-feedstock.git
+	branch = refs/heads/master
 [submodule "labjackpython"]
 	path = feedstocks/labjackpython
 	url = https://github.com/conda-forge/labjackpython-feedstock.git
+	branch = refs/heads/master
 [submodule "lagranto"]
 	path = feedstocks/lagranto
 	url = https://github.com/conda-forge/lagranto-feedstock.git
+	branch = refs/heads/master
 [submodule "landsat_util"]
 	path = feedstocks/landsat_util
 	url = https://github.com/conda-forge/landsat_util-feedstock.git
+	branch = refs/heads/master
 [submodule "lbzip2"]
 	path = feedstocks/lbzip2
 	url = https://github.com/conda-forge/lbzip2-feedstock.git
+	branch = refs/heads/master
 [submodule "libgcrypt"]
 	path = feedstocks/libgcrypt
 	url = https://github.com/conda-forge/libgcrypt-feedstock.git
+	branch = refs/heads/master
 [submodule "libgpg-error"]
 	path = feedstocks/libgpg-error
 	url = https://github.com/conda-forge/libgpg-error-feedstock.git
+	branch = refs/heads/master
 [submodule "libsass"]
 	path = feedstocks/libsass
 	url = https://github.com/conda-forge/libsass-feedstock.git
+	branch = refs/heads/master
 [submodule "louvain"]
 	path = feedstocks/louvain
 	url = https://github.com/conda-forge/louvain-feedstock.git
+	branch = refs/heads/master
 [submodule "m2w64-muparser"]
 	path = feedstocks/m2w64-muparser
 	url = https://github.com/conda-forge/m2w64-muparser-feedstock.git
+	branch = refs/heads/master
 [submodule "maltpynt"]
 	path = feedstocks/maltpynt
 	url = https://github.com/conda-forge/maltpynt-feedstock.git
+	branch = refs/heads/master
 [submodule "mdsrv"]
 	path = feedstocks/mdsrv
 	url = https://github.com/conda-forge/mdsrv-feedstock.git
+	branch = refs/heads/master
 [submodule "mpl-scatter-density"]
 	path = feedstocks/mpl-scatter-density
 	url = https://github.com/conda-forge/mpl-scatter-density-feedstock.git
+	branch = refs/heads/master
 [submodule "naima"]
 	path = feedstocks/naima
 	url = https://github.com/conda-forge/naima-feedstock.git
+	branch = refs/heads/master
 [submodule "ncpol2sdpa"]
 	path = feedstocks/ncpol2sdpa
 	url = https://github.com/conda-forge/ncpol2sdpa-feedstock.git
+	branch = refs/heads/master
 [submodule "nettle"]
 	path = feedstocks/nettle
 	url = https://github.com/conda-forge/nettle-feedstock.git
+	branch = refs/heads/master
 [submodule "omnifit"]
 	path = feedstocks/omnifit
 	url = https://github.com/conda-forge/omnifit-feedstock.git
+	branch = refs/heads/master
 [submodule "opbeat"]
 	path = feedstocks/opbeat
 	url = https://github.com/conda-forge/opbeat-feedstock.git
+	branch = refs/heads/master
 [submodule "openlibm"]
 	path = feedstocks/openlibm
 	url = https://github.com/conda-forge/openlibm-feedstock.git
+	branch = refs/heads/master
 [submodule "openspecfun"]
 	path = feedstocks/openspecfun
 	url = https://github.com/conda-forge/openspecfun-feedstock.git
+	branch = refs/heads/master
 [submodule "oset"]
 	path = feedstocks/oset
 	url = https://github.com/conda-forge/oset-feedstock.git
+	branch = refs/heads/master
 [submodule "oslo.serialization"]
 	path = feedstocks/oslo.serialization
 	url = https://github.com/conda-forge/oslo.serialization-feedstock.git
+	branch = refs/heads/master
 [submodule "pandoc-attributes"]
 	path = feedstocks/pandoc-attributes
 	url = https://github.com/conda-forge/pandoc-attributes-feedstock.git
+	branch = refs/heads/master
 [submodule "passlib"]
 	path = feedstocks/passlib
 	url = https://github.com/conda-forge/passlib-feedstock.git
+	branch = refs/heads/master
 [submodule "pathlib2"]
 	path = feedstocks/pathlib2
 	url = https://github.com/conda-forge/pathlib2-feedstock.git
+	branch = refs/heads/master
 [submodule "pcre2"]
 	path = feedstocks/pcre2
 	url = https://github.com/conda-forge/pcre2-feedstock.git
+	branch = refs/heads/master
 [submodule "perl-app-cpanminus"]
 	path = feedstocks/perl-app-cpanminus
 	url = https://github.com/conda-forge/perl-app-cpanminus-feedstock.git
+	branch = refs/heads/master
 [submodule "pybtex-docutils"]
 	path = feedstocks/pybtex-docutils
 	url = https://github.com/conda-forge/pybtex-docutils-feedstock.git
+	branch = refs/heads/master
 [submodule "pybtex"]
 	path = feedstocks/pybtex
 	url = https://github.com/conda-forge/pybtex-feedstock.git
+	branch = refs/heads/master
 [submodule "pydl"]
 	path = feedstocks/pydl
 	url = https://github.com/conda-forge/pydl-feedstock.git
+	branch = refs/heads/master
 [submodule "pyephem"]
 	path = feedstocks/pyephem
 	url = https://github.com/conda-forge/pyephem-feedstock.git
+	branch = refs/heads/master
 [submodule "pyfmmlib"]
 	path = feedstocks/pyfmmlib
 	url = https://github.com/conda-forge/pyfmmlib-feedstock.git
+	branch = refs/heads/master
 [submodule "pykrige"]
 	path = feedstocks/pykrige
 	url = https://github.com/conda-forge/pykrige-feedstock.git
+	branch = refs/heads/master
 [submodule "pyregion"]
 	path = feedstocks/pyregion
 	url = https://github.com/conda-forge/pyregion-feedstock.git
+	branch = refs/heads/master
 [submodule "pyretis"]
 	path = feedstocks/pyretis
 	url = https://github.com/conda-forge/pyretis-feedstock.git
+	branch = refs/heads/master
 [submodule "pysftp"]
 	path = feedstocks/pysftp
 	url = https://github.com/conda-forge/pysftp-feedstock.git
+	branch = refs/heads/master
 [submodule "pyside2"]
 	path = feedstocks/pyside2
 	url = https://github.com/conda-forge/pyside2-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-forked"]
 	path = feedstocks/pytest-forked
 	url = https://github.com/conda-forge/pytest-forked-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-sugar"]
 	path = feedstocks/pytest-sugar
 	url = https://github.com/conda-forge/pytest-sugar-feedstock.git
+	branch = refs/heads/master
 [submodule "python-cpl"]
 	path = feedstocks/python-cpl
 	url = https://github.com/conda-forge/python-cpl-feedstock.git
+	branch = refs/heads/master
 [submodule "python-ironicclient"]
 	path = feedstocks/python-ironicclient
 	url = https://github.com/conda-forge/python-ironicclient-feedstock.git
+	branch = refs/heads/master
 [submodule "pytrilinos"]
 	path = feedstocks/pytrilinos
 	url = https://github.com/conda-forge/pytrilinos-feedstock.git
+	branch = refs/heads/master
 [submodule "pyuca"]
 	path = feedstocks/pyuca
 	url = https://github.com/conda-forge/pyuca-feedstock.git
+	branch = refs/heads/master
 [submodule "pyutilsnrw"]
 	path = feedstocks/pyutilsnrw
 	url = https://github.com/conda-forge/pyutilsnrw-feedstock.git
+	branch = refs/heads/master
 [submodule "qt.py"]
 	path = feedstocks/qt.py
 	url = https://github.com/conda-forge/qt.py-feedstock.git
+	branch = refs/heads/master
 [submodule "qtkeychain"]
 	path = feedstocks/qtkeychain
 	url = https://github.com/conda-forge/qtkeychain-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ada"]
 	path = feedstocks/r-ada
 	url = https://github.com/conda-forge/r-ada-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ade4"]
 	path = feedstocks/r-ade4
 	url = https://github.com/conda-forge/r-ade4-feedstock.git
+	branch = refs/heads/master
 [submodule "r-agricolae"]
 	path = feedstocks/r-agricolae
 	url = https://github.com/conda-forge/r-agricolae-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ahocorasicktrie"]
 	path = feedstocks/r-ahocorasicktrie
 	url = https://github.com/conda-forge/r-ahocorasicktrie-feedstock.git
+	branch = refs/heads/master
 [submodule "r-algdesign"]
 	path = feedstocks/r-algdesign
 	url = https://github.com/conda-forge/r-algdesign-feedstock.git
+	branch = refs/heads/master
 [submodule "r-amap"]
 	path = feedstocks/r-amap
 	url = https://github.com/conda-forge/r-amap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-aod"]
 	path = feedstocks/r-aod
 	url = https://github.com/conda-forge/r-aod-feedstock.git
+	branch = refs/heads/master
 [submodule "r-argparser"]
 	path = feedstocks/r-argparser
 	url = https://github.com/conda-forge/r-argparser-feedstock.git
+	branch = refs/heads/master
 [submodule "r-aroma.apd"]
 	path = feedstocks/r-aroma.apd
 	url = https://github.com/conda-forge/r-aroma.apd-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ash"]
 	path = feedstocks/r-ash
 	url = https://github.com/conda-forge/r-ash-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ashr"]
 	path = feedstocks/r-ashr
 	url = https://github.com/conda-forge/r-ashr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-base64"]
 	path = feedstocks/r-base64
 	url = https://github.com/conda-forge/r-base64-feedstock.git
+	branch = refs/heads/master
 [submodule "r-batch"]
 	path = feedstocks/r-batch
 	url = https://github.com/conda-forge/r-batch-feedstock.git
+	branch = refs/heads/master
 [submodule "r-batchjobs"]
 	path = feedstocks/r-batchjobs
 	url = https://github.com/conda-forge/r-batchjobs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bbmisc"]
 	path = feedstocks/r-bbmisc
 	url = https://github.com/conda-forge/r-bbmisc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bbmle"]
 	path = feedstocks/r-bbmle
 	url = https://github.com/conda-forge/r-bbmle-feedstock.git
+	branch = refs/heads/master
 [submodule "r-beanplot"]
 	path = feedstocks/r-beanplot
 	url = https://github.com/conda-forge/r-beanplot-feedstock.git
+	branch = refs/heads/master
 [submodule "r-biasedurn"]
 	path = feedstocks/r-biasedurn
 	url = https://github.com/conda-forge/r-biasedurn-feedstock.git
+	branch = refs/heads/master
 [submodule "r-biganalytics"]
 	path = feedstocks/r-biganalytics
 	url = https://github.com/conda-forge/r-biganalytics-feedstock.git
+	branch = refs/heads/master
 [submodule "r-biglm"]
 	path = feedstocks/r-biglm
 	url = https://github.com/conda-forge/r-biglm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bigmemory"]
 	path = feedstocks/r-bigmemory
 	url = https://github.com/conda-forge/r-bigmemory-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bigmemory.sri"]
 	path = feedstocks/r-bigmemory.sri
 	url = https://github.com/conda-forge/r-bigmemory.sri-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bindr"]
 	path = feedstocks/r-bindr
 	url = https://github.com/conda-forge/r-bindr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bindrcpp"]
 	path = feedstocks/r-bindrcpp
 	url = https://github.com/conda-forge/r-bindrcpp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-blockmodeling"]
 	path = feedstocks/r-blockmodeling
 	url = https://github.com/conda-forge/r-blockmodeling-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bma"]
 	path = feedstocks/r-bma
 	url = https://github.com/conda-forge/r-bma-feedstock.git
+	branch = refs/heads/master
 [submodule "r-calibrate"]
 	path = feedstocks/r-calibrate
 	url = https://github.com/conda-forge/r-calibrate-feedstock.git
+	branch = refs/heads/master
 [submodule "r-caroline"]
 	path = feedstocks/r-caroline
 	url = https://github.com/conda-forge/r-caroline-feedstock.git
+	branch = refs/heads/master
 [submodule "r-cghflasso"]
 	path = feedstocks/r-cghflasso
 	url = https://github.com/conda-forge/r-cghflasso-feedstock.git
+	branch = refs/heads/master
 [submodule "r-changepoint"]
 	path = feedstocks/r-changepoint
 	url = https://github.com/conda-forge/r-changepoint-feedstock.git
+	branch = refs/heads/master
 [submodule "r-checkpoint"]
 	path = feedstocks/r-checkpoint
 	url = https://github.com/conda-forge/r-checkpoint-feedstock.git
+	branch = refs/heads/master
 [submodule "r-circlize"]
 	path = feedstocks/r-circlize
 	url = https://github.com/conda-forge/r-circlize-feedstock.git
+	branch = refs/heads/master
 [submodule "r-combinat"]
 	path = feedstocks/r-combinat
 	url = https://github.com/conda-forge/r-combinat-feedstock.git
+	branch = refs/heads/master
 [submodule "r-compquadform"]
 	path = feedstocks/r-compquadform
 	url = https://github.com/conda-forge/r-compquadform-feedstock.git
+	branch = refs/heads/master
 [submodule "r-compute.es"]
 	path = feedstocks/r-compute.es
 	url = https://github.com/conda-forge/r-compute.es-feedstock.git
+	branch = refs/heads/master
 [submodule "r-corpcor"]
 	path = feedstocks/r-corpcor
 	url = https://github.com/conda-forge/r-corpcor-feedstock.git
+	branch = refs/heads/master
 [submodule "r-corrplot"]
 	path = feedstocks/r-corrplot
 	url = https://github.com/conda-forge/r-corrplot-feedstock.git
+	branch = refs/heads/master
 [submodule "r-d3heatmap"]
 	path = feedstocks/r-d3heatmap
 	url = https://github.com/conda-forge/r-d3heatmap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dbplyr"]
 	path = feedstocks/r-dbplyr
 	url = https://github.com/conda-forge/r-dbplyr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-delaporte"]
 	path = feedstocks/r-delaporte
 	url = https://github.com/conda-forge/r-delaporte-feedstock.git
+	branch = refs/heads/master
 [submodule "r-deldir"]
 	path = feedstocks/r-deldir
 	url = https://github.com/conda-forge/r-deldir-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dendextend"]
 	path = feedstocks/r-dendextend
 	url = https://github.com/conda-forge/r-dendextend-feedstock.git
+	branch = refs/heads/master
 [submodule "r-diagram"]
 	path = feedstocks/r-diagram
 	url = https://github.com/conda-forge/r-diagram-feedstock.git
+	branch = refs/heads/master
 [submodule "r-discriminer"]
 	path = feedstocks/r-discriminer
 	url = https://github.com/conda-forge/r-discriminer-feedstock.git
+	branch = refs/heads/master
 [submodule "r-docopt"]
 	path = feedstocks/r-docopt
 	url = https://github.com/conda-forge/r-docopt-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dorng"]
 	path = feedstocks/r-dorng
 	url = https://github.com/conda-forge/r-dorng-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dosnow"]
 	path = feedstocks/r-dosnow
 	url = https://github.com/conda-forge/r-dosnow-feedstock.git
+	branch = refs/heads/master
 [submodule "r-downloader"]
 	path = feedstocks/r-downloader
 	url = https://github.com/conda-forge/r-downloader-feedstock.git
+	branch = refs/heads/master
 [submodule "r-dunn.test"]
 	path = feedstocks/r-dunn.test
 	url = https://github.com/conda-forge/r-dunn.test-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ellipse"]
 	path = feedstocks/r-ellipse
 	url = https://github.com/conda-forge/r-ellipse-feedstock.git
+	branch = refs/heads/master
 [submodule "r-emdbook"]
 	path = feedstocks/r-emdbook
 	url = https://github.com/conda-forge/r-emdbook-feedstock.git
+	branch = refs/heads/master
 [submodule "r-envstats"]
 	path = feedstocks/r-envstats
 	url = https://github.com/conda-forge/r-envstats-feedstock.git
+	branch = refs/heads/master
 [submodule "r-etrunct"]
 	path = feedstocks/r-etrunct
 	url = https://github.com/conda-forge/r-etrunct-feedstock.git
+	branch = refs/heads/master
 [submodule "r-exactranktests"]
 	path = feedstocks/r-exactranktests
 	url = https://github.com/conda-forge/r-exactranktests-feedstock.git
+	branch = refs/heads/master
 [submodule "r-expm"]
 	path = feedstocks/r-expm
 	url = https://github.com/conda-forge/r-expm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-extrafont"]
 	path = feedstocks/r-extrafont
 	url = https://github.com/conda-forge/r-extrafont-feedstock.git
+	branch = refs/heads/master
 [submodule "r-extrafontdb"]
 	path = feedstocks/r-extrafontdb
 	url = https://github.com/conda-forge/r-extrafontdb-feedstock.git
+	branch = refs/heads/master
 [submodule "r-factominer"]
 	path = feedstocks/r-factominer
 	url = https://github.com/conda-forge/r-factominer-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fail"]
 	path = feedstocks/r-fail
 	url = https://github.com/conda-forge/r-fail-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fastmatch"]
 	path = feedstocks/r-fastmatch
 	url = https://github.com/conda-forge/r-fastmatch-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fda"]
 	path = feedstocks/r-fda
 	url = https://github.com/conda-forge/r-fda-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fdrtool"]
 	path = feedstocks/r-fdrtool
 	url = https://github.com/conda-forge/r-fdrtool-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ff"]
 	path = feedstocks/r-ff
 	url = https://github.com/conda-forge/r-ff-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fftwtools"]
 	path = feedstocks/r-fftwtools
 	url = https://github.com/conda-forge/r-fftwtools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fields"]
 	path = feedstocks/r-fields
 	url = https://github.com/conda-forge/r-fields-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fitdistrplus"]
 	path = feedstocks/r-fitdistrplus
 	url = https://github.com/conda-forge/r-fitdistrplus-feedstock.git
+	branch = refs/heads/master
 [submodule "r-flashclust"]
 	path = feedstocks/r-flashclust
 	url = https://github.com/conda-forge/r-flashclust-feedstock.git
+	branch = refs/heads/master
 [submodule "r-flexclust"]
 	path = feedstocks/r-flexclust
 	url = https://github.com/conda-forge/r-flexclust-feedstock.git
+	branch = refs/heads/master
 [submodule "r-flexmix"]
 	path = feedstocks/r-flexmix
 	url = https://github.com/conda-forge/r-flexmix-feedstock.git
+	branch = refs/heads/master
 [submodule "r-flowr"]
 	path = feedstocks/r-flowr
 	url = https://github.com/conda-forge/r-flowr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fpc"]
 	path = feedstocks/r-fpc
 	url = https://github.com/conda-forge/r-fpc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-funr"]
 	path = feedstocks/r-funr
 	url = https://github.com/conda-forge/r-funr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-futile.logger"]
 	path = feedstocks/r-futile.logger
 	url = https://github.com/conda-forge/r-futile.logger-feedstock.git
+	branch = refs/heads/master
 [submodule "r-futile.options"]
 	path = feedstocks/r-futile.options
 	url = https://github.com/conda-forge/r-futile.options-feedstock.git
+	branch = refs/heads/master
 [submodule "r-future"]
 	path = feedstocks/r-future
 	url = https://github.com/conda-forge/r-future-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gam"]
 	path = feedstocks/r-gam
 	url = https://github.com/conda-forge/r-gam-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gamlss"]
 	path = feedstocks/r-gamlss
 	url = https://github.com/conda-forge/r-gamlss-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gamlss.data"]
 	path = feedstocks/r-gamlss.data
 	url = https://github.com/conda-forge/r-gamlss.data-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gamlss.dist"]
 	path = feedstocks/r-gamlss.dist
 	url = https://github.com/conda-forge/r-gamlss.dist-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gbm"]
 	path = feedstocks/r-gbm
 	url = https://github.com/conda-forge/r-gbm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gdtools"]
 	path = feedstocks/r-gdtools
 	url = https://github.com/conda-forge/r-gdtools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-genabel.data"]
 	path = feedstocks/r-genabel.data
 	url = https://github.com/conda-forge/r-genabel.data-feedstock.git
+	branch = refs/heads/master
 [submodule "r-geomap"]
 	path = feedstocks/r-geomap
 	url = https://github.com/conda-forge/r-geomap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-getoptlong"]
 	path = feedstocks/r-getoptlong
 	url = https://github.com/conda-forge/r-getoptlong-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggally"]
 	path = feedstocks/r-ggally
 	url = https://github.com/conda-forge/r-ggally-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggalt"]
 	path = feedstocks/r-ggalt
 	url = https://github.com/conda-forge/r-ggalt-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggbeeswarm"]
 	path = feedstocks/r-ggbeeswarm
 	url = https://github.com/conda-forge/r-ggbeeswarm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggdendro"]
 	path = feedstocks/r-ggdendro
 	url = https://github.com/conda-forge/r-ggdendro-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggrepel"]
 	path = feedstocks/r-ggrepel
 	url = https://github.com/conda-forge/r-ggrepel-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ggthemes"]
 	path = feedstocks/r-ggthemes
 	url = https://github.com/conda-forge/r-ggthemes-feedstock.git
+	branch = refs/heads/master
 [submodule "r-giant"]
 	path = feedstocks/r-giant
 	url = https://github.com/conda-forge/r-giant-feedstock.git
+	branch = refs/heads/master
 [submodule "r-globaloptions"]
 	path = feedstocks/r-globaloptions
 	url = https://github.com/conda-forge/r-globaloptions-feedstock.git
+	branch = refs/heads/master
 [submodule "r-globals"]
 	path = feedstocks/r-globals
 	url = https://github.com/conda-forge/r-globals-feedstock.git
+	branch = refs/heads/master
 [submodule "r-glue"]
 	path = feedstocks/r-glue
 	url = https://github.com/conda-forge/r-glue-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gmd"]
 	path = feedstocks/r-gmd
 	url = https://github.com/conda-forge/r-gmd-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gmodels"]
 	path = feedstocks/r-gmodels
 	url = https://github.com/conda-forge/r-gmodels-feedstock.git
+	branch = refs/heads/master
 [submodule "r-googlevis"]
 	path = feedstocks/r-googlevis
 	url = https://github.com/conda-forge/r-googlevis-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gprofiler"]
 	path = feedstocks/r-gprofiler
 	url = https://github.com/conda-forge/r-gprofiler-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gpseq"]
 	path = feedstocks/r-gpseq
 	url = https://github.com/conda-forge/r-gpseq-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gridgraphics"]
 	path = feedstocks/r-gridgraphics
 	url = https://github.com/conda-forge/r-gridgraphics-feedstock.git
+	branch = refs/heads/master
 [submodule "r-grimport"]
 	path = feedstocks/r-grimport
 	url = https://github.com/conda-forge/r-grimport-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gsalib"]
 	path = feedstocks/r-gsalib
 	url = https://github.com/conda-forge/r-gsalib-feedstock.git
+	branch = refs/heads/master
 [submodule "r-gsmoothr"]
 	path = feedstocks/r-gsmoothr
 	url = https://github.com/conda-forge/r-gsmoothr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hash"]
 	path = feedstocks/r-hash
 	url = https://github.com/conda-forge/r-hash-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hdrcde"]
 	path = feedstocks/r-hdrcde
 	url = https://github.com/conda-forge/r-hdrcde-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hwriter"]
 	path = feedstocks/r-hwriter
 	url = https://github.com/conda-forge/r-hwriter-feedstock.git
+	branch = refs/heads/master
 [submodule "r-idpmisc"]
 	path = feedstocks/r-idpmisc
 	url = https://github.com/conda-forge/r-idpmisc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-idr"]
 	path = feedstocks/r-idr
 	url = https://github.com/conda-forge/r-idr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-inlinedocs"]
 	path = feedstocks/r-inlinedocs
 	url = https://github.com/conda-forge/r-inlinedocs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-intamap"]
 	path = feedstocks/r-intamap
 	url = https://github.com/conda-forge/r-intamap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-itertools"]
 	path = feedstocks/r-itertools
 	url = https://github.com/conda-forge/r-itertools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-kernlab"]
 	path = feedstocks/r-kernlab
 	url = https://github.com/conda-forge/r-kernlab-feedstock.git
+	branch = refs/heads/master
 [submodule "r-klar"]
 	path = feedstocks/r-klar
 	url = https://github.com/conda-forge/r-klar-feedstock.git
+	branch = refs/heads/master
 [submodule "r-km.ci"]
 	path = feedstocks/r-km.ci
 	url = https://github.com/conda-forge/r-km.ci-feedstock.git
+	branch = refs/heads/master
 [submodule "r-kmsurv"]
 	path = feedstocks/r-kmsurv
 	url = https://github.com/conda-forge/r-kmsurv-feedstock.git
+	branch = refs/heads/master
 [submodule "r-knitrbootstrap"]
 	path = feedstocks/r-knitrbootstrap
 	url = https://github.com/conda-forge/r-knitrbootstrap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-kriging"]
 	path = feedstocks/r-kriging
 	url = https://github.com/conda-forge/r-kriging-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ks"]
 	path = feedstocks/r-ks
 	url = https://github.com/conda-forge/r-ks-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lambda.r"]
 	path = feedstocks/r-lambda.r
 	url = https://github.com/conda-forge/r-lambda.r-feedstock.git
+	branch = refs/heads/master
 [submodule "r-learnbayes"]
 	path = feedstocks/r-learnbayes
 	url = https://github.com/conda-forge/r-learnbayes-feedstock.git
+	branch = refs/heads/master
 [submodule "r-listenv"]
 	path = feedstocks/r-listenv
 	url = https://github.com/conda-forge/r-listenv-feedstock.git
+	branch = refs/heads/master
 [submodule "r-locfdr"]
 	path = feedstocks/r-locfdr
 	url = https://github.com/conda-forge/r-locfdr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-locfit"]
 	path = feedstocks/r-locfit
 	url = https://github.com/conda-forge/r-locfit-feedstock.git
+	branch = refs/heads/master
 [submodule "r-longitudinal"]
 	path = feedstocks/r-longitudinal
 	url = https://github.com/conda-forge/r-longitudinal-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lsd"]
 	path = feedstocks/r-lsd
 	url = https://github.com/conda-forge/r-lsd-feedstock.git
+	branch = refs/heads/master
 [submodule "r-matlab"]
 	path = feedstocks/r-matlab
 	url = https://github.com/conda-forge/r-matlab-feedstock.git
+	branch = refs/heads/master
 [submodule "r-maxlik"]
 	path = feedstocks/r-maxlik
 	url = https://github.com/conda-forge/r-maxlik-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mba"]
 	path = feedstocks/r-mba
 	url = https://github.com/conda-forge/r-mba-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mclust"]
 	path = feedstocks/r-mclust
 	url = https://github.com/conda-forge/r-mclust-feedstock.git
+	branch = refs/heads/master
 [submodule "r-memuse"]
 	path = feedstocks/r-memuse
 	url = https://github.com/conda-forge/r-memuse-feedstock.git
+	branch = refs/heads/master
 [submodule "r-minpack.lm"]
 	path = feedstocks/r-minpack.lm
 	url = https://github.com/conda-forge/r-minpack.lm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-misc3d"]
 	path = feedstocks/r-misc3d
 	url = https://github.com/conda-forge/r-misc3d-feedstock.git
+	branch = refs/heads/master
 [submodule "r-misctools"]
 	path = feedstocks/r-misctools
 	url = https://github.com/conda-forge/r-misctools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-missforest"]
 	path = feedstocks/r-missforest
 	url = https://github.com/conda-forge/r-missforest-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mitools"]
 	path = feedstocks/r-mitools
 	url = https://github.com/conda-forge/r-mitools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mixtools"]
 	path = feedstocks/r-mixtools
 	url = https://github.com/conda-forge/r-mixtools-feedstock.git
+	branch = refs/heads/master
 [submodule "r-multicool"]
 	path = feedstocks/r-multicool
 	url = https://github.com/conda-forge/r-multicool-feedstock.git
+	branch = refs/heads/master
 [submodule "r-multitaper"]
 	path = feedstocks/r-multitaper
 	url = https://github.com/conda-forge/r-multitaper-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nhmmfdr"]
 	path = feedstocks/r-nhmmfdr
 	url = https://github.com/conda-forge/r-nhmmfdr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nleqslv"]
 	path = feedstocks/r-nleqslv
 	url = https://github.com/conda-forge/r-nleqslv-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nor1mix"]
 	path = feedstocks/r-nor1mix
 	url = https://github.com/conda-forge/r-nor1mix-feedstock.git
+	branch = refs/heads/master
 [submodule "r-nozzle.r1"]
 	path = feedstocks/r-nozzle.r1
 	url = https://github.com/conda-forge/r-nozzle.r1-feedstock.git
+	branch = refs/heads/master
 [submodule "r-openxlsx"]
 	path = feedstocks/r-openxlsx
 	url = https://github.com/conda-forge/r-openxlsx-feedstock.git
+	branch = refs/heads/master
 [submodule "r-optparse"]
 	path = feedstocks/r-optparse
 	url = https://github.com/conda-forge/r-optparse-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ore"]
 	path = feedstocks/r-ore
 	url = https://github.com/conda-forge/r-ore-feedstock.git
+	branch = refs/heads/master
 [submodule "r-outliers"]
 	path = feedstocks/r-outliers
 	url = https://github.com/conda-forge/r-outliers-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pack"]
 	path = feedstocks/r-pack
 	url = https://github.com/conda-forge/r-pack-feedstock.git
+	branch = refs/heads/master
 [submodule "r-params"]
 	path = feedstocks/r-params
 	url = https://github.com/conda-forge/r-params-feedstock.git
+	branch = refs/heads/master
 [submodule "r-penalized"]
 	path = feedstocks/r-penalized
 	url = https://github.com/conda-forge/r-penalized-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pheatmap"]
 	path = feedstocks/r-pheatmap
 	url = https://github.com/conda-forge/r-pheatmap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-phonr"]
 	path = feedstocks/r-phonr
 	url = https://github.com/conda-forge/r-phonr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pkgconfig"]
 	path = feedstocks/r-pkgconfig
 	url = https://github.com/conda-forge/r-pkgconfig-feedstock.git
+	branch = refs/heads/master
 [submodule "r-plotly"]
 	path = feedstocks/r-plotly
 	url = https://github.com/conda-forge/r-plotly-feedstock.git
+	branch = refs/heads/master
 [submodule "r-plotrix"]
 	path = feedstocks/r-plotrix
 	url = https://github.com/conda-forge/r-plotrix-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pmcmr"]
 	path = feedstocks/r-pmcmr
 	url = https://github.com/conda-forge/r-pmcmr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-polynom"]
 	path = feedstocks/r-polynom
 	url = https://github.com/conda-forge/r-polynom-feedstock.git
+	branch = refs/heads/master
 [submodule "r-prabclus"]
 	path = feedstocks/r-prabclus
 	url = https://github.com/conda-forge/r-prabclus-feedstock.git
+	branch = refs/heads/master
 [submodule "r-preseqr"]
 	path = feedstocks/r-preseqr
 	url = https://github.com/conda-forge/r-preseqr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-prettyunits"]
 	path = feedstocks/r-prettyunits
 	url = https://github.com/conda-forge/r-prettyunits-feedstock.git
+	branch = refs/heads/master
 [submodule "r-progress"]
 	path = feedstocks/r-progress
 	url = https://github.com/conda-forge/r-progress-feedstock.git
+	branch = refs/heads/master
 [submodule "r-proj4"]
 	path = feedstocks/r-proj4
 	url = https://github.com/conda-forge/r-proj4-feedstock.git
+	branch = refs/heads/master
 [submodule "r-prroc"]
 	path = feedstocks/r-prroc
 	url = https://github.com/conda-forge/r-prroc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pscl"]
 	path = feedstocks/r-pscl
 	url = https://github.com/conda-forge/r-pscl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ptw"]
 	path = feedstocks/r-ptw
 	url = https://github.com/conda-forge/r-ptw-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.cache"]
 	path = feedstocks/r-r.cache
 	url = https://github.com/conda-forge/r-r.cache-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.devices"]
 	path = feedstocks/r-r.devices
 	url = https://github.com/conda-forge/r-r.devices-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.filesets"]
 	path = feedstocks/r-r.filesets
 	url = https://github.com/conda-forge/r-r.filesets-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.huge"]
 	path = feedstocks/r-r.huge
 	url = https://github.com/conda-forge/r-r.huge-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r.rsp"]
 	path = feedstocks/r-r.rsp
 	url = https://github.com/conda-forge/r-r.rsp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-r2html"]
 	path = feedstocks/r-r2html
 	url = https://github.com/conda-forge/r-r2html-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rainbow"]
 	path = feedstocks/r-rainbow
 	url = https://github.com/conda-forge/r-rainbow-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcppgsl"]
 	path = feedstocks/r-rcppgsl
 	url = https://github.com/conda-forge/r-rcppgsl-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcppparallel"]
 	path = feedstocks/r-rcppparallel
 	url = https://github.com/conda-forge/r-rcppparallel-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rcpptoml"]
 	path = feedstocks/r-rcpptoml
 	url = https://github.com/conda-forge/r-rcpptoml-feedstock.git
+	branch = refs/heads/master
 [submodule "r-relaimpo"]
 	path = feedstocks/r-relaimpo
 	url = https://github.com/conda-forge/r-relaimpo-feedstock.git
+	branch = refs/heads/master
 [submodule "r-relations"]
 	path = feedstocks/r-relations
 	url = https://github.com/conda-forge/r-relations-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rfoc"]
 	path = feedstocks/r-rfoc
 	url = https://github.com/conda-forge/r-rfoc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rlang"]
 	path = feedstocks/r-rlang
 	url = https://github.com/conda-forge/r-rlang-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rnifti"]
 	path = feedstocks/r-rnifti
 	url = https://github.com/conda-forge/r-rnifti-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rniftyreg"]
 	path = feedstocks/r-rniftyreg
 	url = https://github.com/conda-forge/r-rniftyreg-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rpmg"]
 	path = feedstocks/r-rpmg
 	url = https://github.com/conda-forge/r-rpmg-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rrcov"]
 	path = feedstocks/r-rrcov
 	url = https://github.com/conda-forge/r-rrcov-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rseis"]
 	path = feedstocks/r-rseis
 	url = https://github.com/conda-forge/r-rseis-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rsm"]
 	path = feedstocks/r-rsm
 	url = https://github.com/conda-forge/r-rsm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rsolnp"]
 	path = feedstocks/r-rsolnp
 	url = https://github.com/conda-forge/r-rsolnp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rttf2pt1"]
 	path = feedstocks/r-rttf2pt1
 	url = https://github.com/conda-forge/r-rttf2pt1-feedstock.git
+	branch = refs/heads/master
 [submodule "r-runit"]
 	path = feedstocks/r-runit
 	url = https://github.com/conda-forge/r-runit-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rwave"]
 	path = feedstocks/r-rwave
 	url = https://github.com/conda-forge/r-rwave-feedstock.git
+	branch = refs/heads/master
 [submodule "r-scatterplot3d"]
 	path = feedstocks/r-scatterplot3d
 	url = https://github.com/conda-forge/r-scatterplot3d-feedstock.git
+	branch = refs/heads/master
 [submodule "r-segmented"]
 	path = feedstocks/r-segmented
 	url = https://github.com/conda-forge/r-segmented-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sendmailr"]
 	path = feedstocks/r-sendmailr
 	url = https://github.com/conda-forge/r-sendmailr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sets"]
 	path = feedstocks/r-sets
 	url = https://github.com/conda-forge/r-sets-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shape"]
 	path = feedstocks/r-shape
 	url = https://github.com/conda-forge/r-shape-feedstock.git
+	branch = refs/heads/master
 [submodule "r-signal"]
 	path = feedstocks/r-signal
 	url = https://github.com/conda-forge/r-signal-feedstock.git
+	branch = refs/heads/master
 [submodule "r-skellam"]
 	path = feedstocks/r-skellam
 	url = https://github.com/conda-forge/r-skellam-feedstock.git
+	branch = refs/heads/master
 [submodule "r-snow"]
 	path = feedstocks/r-snow
 	url = https://github.com/conda-forge/r-snow-feedstock.git
+	branch = refs/heads/master
 [submodule "r-snowfall"]
 	path = feedstocks/r-snowfall
 	url = https://github.com/conda-forge/r-snowfall-feedstock.git
+	branch = refs/heads/master
 [submodule "r-som"]
 	path = feedstocks/r-som
 	url = https://github.com/conda-forge/r-som-feedstock.git
+	branch = refs/heads/master
 [submodule "r-spam"]
 	path = feedstocks/r-spam
 	url = https://github.com/conda-forge/r-spam-feedstock.git
+	branch = refs/heads/master
 [submodule "r-spdep"]
 	path = feedstocks/r-spdep
 	url = https://github.com/conda-forge/r-spdep-feedstock.git
+	branch = refs/heads/master
 [submodule "r-speedglm"]
 	path = feedstocks/r-speedglm
 	url = https://github.com/conda-forge/r-speedglm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-splancs"]
 	path = feedstocks/r-splancs
 	url = https://github.com/conda-forge/r-splancs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-splitstackshape"]
 	path = feedstocks/r-splitstackshape
 	url = https://github.com/conda-forge/r-splitstackshape-feedstock.git
+	branch = refs/heads/master
 [submodule "r-squarem"]
 	path = feedstocks/r-squarem
 	url = https://github.com/conda-forge/r-squarem-feedstock.git
+	branch = refs/heads/master
 [submodule "r-statmod"]
 	path = feedstocks/r-statmod
 	url = https://github.com/conda-forge/r-statmod-feedstock.git
+	branch = refs/heads/master
 [submodule "r-survey"]
 	path = feedstocks/r-survey
 	url = https://github.com/conda-forge/r-survey-feedstock.git
+	branch = refs/heads/master
 [submodule "r-svdialogs"]
 	path = feedstocks/r-svdialogs
 	url = https://github.com/conda-forge/r-svdialogs-feedstock.git
+	branch = refs/heads/master
 [submodule "r-svgui"]
 	path = feedstocks/r-svgui
 	url = https://github.com/conda-forge/r-svgui-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tiff"]
 	path = feedstocks/r-tiff
 	url = https://github.com/conda-forge/r-tiff-feedstock.git
+	branch = refs/heads/master
 [submodule "r-trimcluster"]
 	path = feedstocks/r-trimcluster
 	url = https://github.com/conda-forge/r-trimcluster-feedstock.git
+	branch = refs/heads/master
 [submodule "r-truncnorm"]
 	path = feedstocks/r-truncnorm
 	url = https://github.com/conda-forge/r-truncnorm-feedstock.git
+	branch = refs/heads/master
 [submodule "r-tsne"]
 	path = feedstocks/r-tsne
 	url = https://github.com/conda-forge/r-tsne-feedstock.git
+	branch = refs/heads/master
 [submodule "r-upsetr"]
 	path = feedstocks/r-upsetr
 	url = https://github.com/conda-forge/r-upsetr-feedstock.git
+	branch = refs/heads/master
 [submodule "r-venn"]
 	path = feedstocks/r-venn
 	url = https://github.com/conda-forge/r-venn-feedstock.git
+	branch = refs/heads/master
 [submodule "r-venndiagram"]
 	path = feedstocks/r-venndiagram
 	url = https://github.com/conda-forge/r-venndiagram-feedstock.git
+	branch = refs/heads/master
 [submodule "r-waveslim"]
 	path = feedstocks/r-waveslim
 	url = https://github.com/conda-forge/r-waveslim-feedstock.git
+	branch = refs/heads/master
 [submodule "r-wrassp"]
 	path = feedstocks/r-wrassp
 	url = https://github.com/conda-forge/r-wrassp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-writexls"]
 	path = feedstocks/r-writexls
 	url = https://github.com/conda-forge/r-writexls-feedstock.git
+	branch = refs/heads/master
 [submodule "ratelimiter"]
 	path = feedstocks/ratelimiter
 	url = https://github.com/conda-forge/ratelimiter-feedstock.git
+	branch = refs/heads/master
 [submodule "rcssmin"]
 	path = feedstocks/rcssmin
 	url = https://github.com/conda-forge/rcssmin-feedstock.git
+	branch = refs/heads/master
 [submodule "regions"]
 	path = feedstocks/regions
 	url = https://github.com/conda-forge/regions-feedstock.git
+	branch = refs/heads/master
 [submodule "rjsmin"]
 	path = feedstocks/rjsmin
 	url = https://github.com/conda-forge/rjsmin-feedstock.git
+	branch = refs/heads/master
 [submodule "rt1"]
 	path = feedstocks/rt1
 	url = https://github.com/conda-forge/rt1-feedstock.git
+	branch = refs/heads/master
 [submodule "scattertext"]
 	path = feedstocks/scattertext
 	url = https://github.com/conda-forge/scattertext-feedstock.git
+	branch = refs/heads/master
 [submodule "segno"]
 	path = feedstocks/segno
 	url = https://github.com/conda-forge/segno-feedstock.git
+	branch = refs/heads/master
 [submodule "shade"]
 	path = feedstocks/shade
 	url = https://github.com/conda-forge/shade-feedstock.git
+	branch = refs/heads/master
 [submodule "simplegeneric"]
 	path = feedstocks/simplegeneric
 	url = https://github.com/conda-forge/simplegeneric-feedstock.git
+	branch = refs/heads/master
 [submodule "somoclu"]
 	path = feedstocks/somoclu
 	url = https://github.com/conda-forge/somoclu-feedstock.git
+	branch = refs/heads/master
 [submodule "spectral-cube"]
 	path = feedstocks/spectral-cube
 	url = https://github.com/conda-forge/spectral-cube-feedstock.git
+	branch = refs/heads/master
 [submodule "specutils"]
 	path = feedstocks/specutils
 	url = https://github.com/conda-forge/specutils-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxcontrib-bibtex"]
 	path = feedstocks/sphinxcontrib-bibtex
 	url = https://github.com/conda-forge/sphinxcontrib-bibtex-feedstock.git
+	branch = refs/heads/master
 [submodule "sphinxcontrib-spelling"]
 	path = feedstocks/sphinxcontrib-spelling
 	url = https://github.com/conda-forge/sphinxcontrib-spelling-feedstock.git
+	branch = refs/heads/master
 [submodule "spyder-reports"]
 	path = feedstocks/spyder-reports
 	url = https://github.com/conda-forge/spyder-reports-feedstock.git
+	branch = refs/heads/master
 [submodule "spyder-terminal"]
 	path = feedstocks/spyder-terminal
 	url = https://github.com/conda-forge/spyder-terminal-feedstock.git
+	branch = refs/heads/master
 [submodule "ssh2-python"]
 	path = feedstocks/ssh2-python
 	url = https://github.com/conda-forge/ssh2-python-feedstock.git
+	branch = refs/heads/master
 [submodule "streamz"]
 	path = feedstocks/streamz
 	url = https://github.com/conda-forge/streamz-feedstock.git
+	branch = refs/heads/master
 [submodule "swiglpk"]
 	path = feedstocks/swiglpk
 	url = https://github.com/conda-forge/swiglpk-feedstock.git
+	branch = refs/heads/master
 [submodule "terminaltables"]
 	path = feedstocks/terminaltables
 	url = https://github.com/conda-forge/terminaltables-feedstock.git
+	branch = refs/heads/master
 [submodule "theanolm"]
 	path = feedstocks/theanolm
 	url = https://github.com/conda-forge/theanolm-feedstock.git
+	branch = refs/heads/master
 [submodule "toml"]
 	path = feedstocks/toml
 	url = https://github.com/conda-forge/toml-feedstock.git
+	branch = refs/heads/master
 [submodule "tox"]
 	path = feedstocks/tox
 	url = https://github.com/conda-forge/tox-feedstock.git
+	branch = refs/heads/master
 [submodule "visdom"]
 	path = feedstocks/visdom
 	url = https://github.com/conda-forge/visdom-feedstock.git
+	branch = refs/heads/master
 [submodule "w3m"]
 	path = feedstocks/w3m
 	url = https://github.com/conda-forge/w3m-feedstock.git
+	branch = refs/heads/master
 [submodule "whitenoise"]
 	path = feedstocks/whitenoise
 	url = https://github.com/conda-forge/whitenoise-feedstock.git
+	branch = refs/heads/master
 [submodule "willow"]
 	path = feedstocks/willow
 	url = https://github.com/conda-forge/willow-feedstock.git
+	branch = refs/heads/master
 [submodule "xbpch"]
 	path = feedstocks/xbpch
 	url = https://github.com/conda-forge/xbpch-feedstock.git
+	branch = refs/heads/master
 [submodule "xlntpyarrow"]
 	path = feedstocks/xlntpyarrow
 	url = https://github.com/conda-forge/xlntpyarrow-feedstock.git
+	branch = refs/heads/master
 [submodule "xtl"]
 	path = feedstocks/xtl
 	url = https://github.com/conda-forge/xtl-feedstock.git
+	branch = refs/heads/master
 [submodule "ago"]
 	path = feedstocks/ago
 	url = https://github.com/conda-forge/ago-feedstock.git
+	branch = refs/heads/master
 [submodule "aspy.yaml"]
 	path = feedstocks/aspy.yaml
 	url = https://github.com/conda-forge/aspy.yaml-feedstock.git
+	branch = refs/heads/master
 [submodule "cfortran-cfitsio"]
 	path = feedstocks/cfortran-cfitsio
 	url = https://github.com/conda-forge/cfortran-cfitsio-feedstock.git
+	branch = refs/heads/master
 [submodule "gj2ascii"]
 	path = feedstocks/gj2ascii
 	url = https://github.com/conda-forge/gj2ascii-feedstock.git
+	branch = refs/heads/master
 [submodule "identify"]
 	path = feedstocks/identify
 	url = https://github.com/conda-forge/identify-feedstock.git
+	branch = refs/heads/master
 [submodule "langdetect"]
 	path = feedstocks/langdetect
 	url = https://github.com/conda-forge/langdetect-feedstock.git
+	branch = refs/heads/master
 [submodule "nodeenv"]
 	path = feedstocks/nodeenv
 	url = https://github.com/conda-forge/nodeenv-feedstock.git
+	branch = refs/heads/master
 [submodule "pre_commit"]
 	path = feedstocks/pre_commit
 	url = https://github.com/conda-forge/pre_commit-feedstock.git
+	branch = refs/heads/master
 [submodule "pysw4"]
 	path = feedstocks/pysw4
 	url = https://github.com/conda-forge/pysw4-feedstock.git
+	branch = refs/heads/master
 [submodule "pytest-env"]
 	path = feedstocks/pytest-env
 	url = https://github.com/conda-forge/pytest-env-feedstock.git
+	branch = refs/heads/master
 [submodule "python-decouple"]
 	path = feedstocks/python-decouple
 	url = https://github.com/conda-forge/python-decouple-feedstock.git
+	branch = refs/heads/master
 [submodule "r-colorramps"]
 	path = feedstocks/r-colorramps
 	url = https://github.com/conda-forge/r-colorramps-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sparql"]
 	path = feedstocks/r-sparql
 	url = https://github.com/conda-forge/r-sparql-feedstock.git
+	branch = refs/heads/master
 [submodule "sas_kernel"]
 	path = feedstocks/sas_kernel
 	url = https://github.com/conda-forge/sas_kernel-feedstock.git
+	branch = refs/heads/master
 [submodule "saspy"]
 	path = feedstocks/saspy
 	url = https://github.com/conda-forge/saspy-feedstock.git
+	branch = refs/heads/master
 [submodule "wagtail"]
 	path = feedstocks/wagtail
 	url = https://github.com/conda-forge/wagtail-feedstock.git
+	branch = refs/heads/master
 [submodule "wgrib2"]
 	path = feedstocks/wgrib2
 	url = https://github.com/conda-forge/wgrib2-feedstock.git
+	branch = refs/heads/master
 [submodule "dotmap"]
 	path = feedstocks/dotmap
 	url = https://github.com/conda-forge/dotmap-feedstock.git
+	branch = refs/heads/master
 [submodule "dpath"]
 	path = feedstocks/dpath
 	url = https://github.com/conda-forge/dpath-feedstock.git
+	branch = refs/heads/master
 [submodule "espei"]
 	path = feedstocks/espei
 	url = https://github.com/conda-forge/espei-feedstock.git
+	branch = refs/heads/master
 [submodule "libosxunwind"]
 	path = feedstocks/libosxunwind
 	url = https://github.com/conda-forge/libosxunwind-feedstock.git
+	branch = refs/heads/master
 [submodule "plac"]
 	path = feedstocks/plac
 	url = https://github.com/conda-forge/plac-feedstock.git
+	branch = refs/heads/master
 [submodule "pymssql"]
 	path = feedstocks/pymssql
 	url = https://github.com/conda-forge/pymssql-feedstock.git
+	branch = refs/heads/master
 [submodule "r-powerlaw"]
 	path = feedstocks/r-powerlaw
 	url = https://github.com/conda-forge/r-powerlaw-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rann"]
 	path = feedstocks/r-rann
 	url = https://github.com/conda-forge/r-rann-feedstock.git
+	branch = refs/heads/master
 [submodule "signac-dashboard"]
 	path = feedstocks/signac-dashboard
 	url = https://github.com/conda-forge/signac-dashboard-feedstock.git
+	branch = refs/heads/master
 [submodule "image-meta-tag"]
 	path = feedstocks/image-meta-tag
 	url = https://github.com/conda-forge/image-meta-tag-feedstock.git
+	branch = refs/heads/master
 [submodule "r-betareg"]
 	path = feedstocks/r-betareg
 	url = https://github.com/conda-forge/r-betareg-feedstock.git
+	branch = refs/heads/master
 [submodule "r-hiddenmarkov"]
 	path = feedstocks/r-hiddenmarkov
 	url = https://github.com/conda-forge/r-hiddenmarkov-feedstock.git
+	branch = refs/heads/master
 [submodule "r-lokern"]
 	path = feedstocks/r-lokern
 	url = https://github.com/conda-forge/r-lokern-feedstock.git
+	branch = refs/heads/master
 [submodule "r-pvclust"]
 	path = feedstocks/r-pvclust
 	url = https://github.com/conda-forge/r-pvclust-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rtsne"]
 	path = feedstocks/r-rtsne
 	url = https://github.com/conda-forge/r-rtsne-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sciplot"]
 	path = feedstocks/r-sciplot
 	url = https://github.com/conda-forge/r-sciplot-feedstock.git
+	branch = refs/heads/master
 [submodule "r-sfsmisc"]
 	path = feedstocks/r-sfsmisc
 	url = https://github.com/conda-forge/r-sfsmisc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-shinyace"]
 	path = feedstocks/r-shinyace
 	url = https://github.com/conda-forge/r-shinyace-feedstock.git
+	branch = refs/heads/master
 [submodule "recommonmark"]
 	path = feedstocks/recommonmark
 	url = https://github.com/conda-forge/recommonmark-feedstock.git
+	branch = refs/heads/master
 [submodule "serverfiles"]
 	path = feedstocks/serverfiles
 	url = https://github.com/conda-forge/serverfiles-feedstock.git
+	branch = refs/heads/master
 [submodule "django-bakery"]
 	path = feedstocks/django-bakery
 	url = https://github.com/conda-forge/django-bakery-feedstock.git
+	branch = refs/heads/master
 [submodule "inotify-tools"]
 	path = feedstocks/inotify-tools
 	url = https://github.com/conda-forge/inotify-tools-feedstock.git
+	branch = refs/heads/master
 [submodule "markdown"]
 	path = feedstocks/markdown
 	url = https://github.com/conda-forge/markdown-feedstock.git
+	branch = refs/heads/master
 [submodule "osfclient"]
 	path = feedstocks/osfclient
 	url = https://github.com/conda-forge/osfclient-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bmp"]
 	path = feedstocks/r-bmp
 	url = https://github.com/conda-forge/r-bmp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-clue"]
 	path = feedstocks/r-clue
 	url = https://github.com/conda-forge/r-clue-feedstock.git
+	branch = refs/heads/master
 [submodule "r-contrast"]
 	path = feedstocks/r-contrast
 	url = https://github.com/conda-forge/r-contrast-feedstock.git
+	branch = refs/heads/master
 [submodule "r-ecp"]
 	path = feedstocks/r-ecp
 	url = https://github.com/conda-forge/r-ecp-feedstock.git
+	branch = refs/heads/master
 [submodule "r-feature"]
 	path = feedstocks/r-feature
 	url = https://github.com/conda-forge/r-feature-feedstock.git
+	branch = refs/heads/master
 [submodule "r-geepack"]
 	path = feedstocks/r-geepack
 	url = https://github.com/conda-forge/r-geepack-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mcmc"]
 	path = feedstocks/r-mcmc
 	url = https://github.com/conda-forge/r-mcmc-feedstock.git
+	branch = refs/heads/master
 [submodule "r-mcmcpack"]
 	path = feedstocks/r-mcmcpack
 	url = https://github.com/conda-forge/r-mcmcpack-feedstock.git
+	branch = refs/heads/master
 [submodule "r-moments"]
 	path = feedstocks/r-moments
 	url = https://github.com/conda-forge/r-moments-feedstock.git
+	branch = refs/heads/master
 [submodule "r-polspline"]
 	path = feedstocks/r-polspline
 	url = https://github.com/conda-forge/r-polspline-feedstock.git
+	branch = refs/heads/master
 [submodule "r-readbitmap"]
 	path = feedstocks/r-readbitmap
 	url = https://github.com/conda-forge/r-readbitmap-feedstock.git
+	branch = refs/heads/master
 [submodule "r-rms"]
 	path = feedstocks/r-rms
 	url = https://github.com/conda-forge/r-rms-feedstock.git
+	branch = refs/heads/master
 [submodule "r-wavethresh"]
 	path = feedstocks/r-wavethresh
 	url = https://github.com/conda-forge/r-wavethresh-feedstock.git
+	branch = refs/heads/master
 [submodule "svgutils"]
 	path = feedstocks/svgutils
 	url = https://github.com/conda-forge/svgutils-feedstock.git
+	branch = refs/heads/master
 [submodule "gnutls"]
 	path = feedstocks/gnutls
 	url = https://github.com/conda-forge/gnutls-feedstock.git
+	branch = refs/heads/master
 [submodule "hcephes"]
 	path = feedstocks/hcephes
 	url = https://github.com/conda-forge/hcephes-feedstock.git
+	branch = refs/heads/master
 [submodule "orekit"]
 	path = feedstocks/orekit
 	url = https://github.com/conda-forge/orekit-feedstock.git
+	branch = refs/heads/master
 [submodule "r-fst"]
 	path = feedstocks/r-fst
 	url = https://github.com/conda-forge/r-fst-feedstock.git
+	branch = refs/heads/master
 [submodule "r-naturalsort"]
 	path = feedstocks/r-naturalsort
 	url = https://github.com/conda-forge/r-naturalsort-feedstock.git
+	branch = refs/heads/master
 [submodule "dionysus"]
 	path = feedstocks/dionysus
 	url = https://github.com/conda-forge/dionysus-feedstock.git
+	branch = refs/heads/master
 [submodule "fs"]
 	path = feedstocks/fs
 	url = https://github.com/conda-forge/fs-feedstock.git
+	branch = refs/heads/master
 [submodule "nose-progressive"]
 	path = feedstocks/nose-progressive
 	url = https://github.com/conda-forge/nose-progressive-feedstock.git
+	branch = refs/heads/master
 [submodule "green"]
 	path = feedstocks/green
 	url = https://github.com/conda-forge/green-feedstock.git
+	branch = refs/heads/master
 [submodule "r-bibtex"]
 	path = feedstocks/r-bibtex
 	url = https://github.com/conda-forge/r-bibtex-feedstock.git
+	branch = refs/heads/master
 [submodule "r-captioner"]
 	path = feedstocks/r-captioner
 	url = https://github.com/conda-forge/r-captioner-feedstock.git
+	branch = refs/heads/master
 [submodule "trilinos"]
 	path = feedstocks/trilinos
 	url = https://github.com/conda-forge/trilinos-feedstock.git
+	branch = refs/heads/master
 [submodule "flask-allows"]
 	url = https://github.com/conda-forge/flask-allows-feedstock.git
 	path = feedstocks/flask-allows


### PR DESCRIPTION
The upstream branch was set for some submodules and not others. As the feedstock webservice does set the upstream branch on new feedstocks added to the repo, it makes sense to update any other feedstocks to similarly specify this information, which is what this commit does.