### PR TITLE
Remove cgsn-parsers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6342,10 +6342,6 @@
 	path = feedstocks/appnope
 	url = https://github.com/conda-forge/appnope-feedstock.git
 	branch = refs/heads/master
-[submodule "cgsn-parsers"]
-	path = feedstocks/cgsn-parsers
-	url = https://github.com/conda-forge/cgsn-parsers-feedstock.git
-	branch = refs/heads/master
 [submodule "clangdev"]
 	path = feedstocks/clangdev
 	url = https://github.com/conda-forge/clangdev-feedstock.git


### PR DESCRIPTION
Fixes https://github.com/conda-forge/feedstocks/issues/21

The feedstock has been renamed to `cgsn_parsers`. So `cgsn-parsers` should be removed.

cc @mbargull