### PR TITLE
Remove `bowtie` feedstock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15914,10 +15914,6 @@
 	url = https://github.com/conda-forge/sphinxcontrib-programoutput-feedstock.git
 	path = feedstocks/sphinxcontrib-programoutput
 	branch = refs/heads/master
-[submodule "bowtie"]
-	url = https://github.com/conda-forge/bowtie-feedstock.git
-	path = feedstocks/bowtie
-	branch = refs/heads/master
 [submodule "django-mptt"]
 	url = https://github.com/conda-forge/django-mptt-feedstock.git
 	path = feedstocks/django-mptt


### PR DESCRIPTION
The feedstock has been deleted and added under a different name. This goes ahead and removes it from the `feedstocks` repo.