### PR TITLE
Rename `python-drmaa` to `drmaa`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1191,7 +1191,7 @@
 	url = https://github.com/conda-forge/ptyprocess-feedstock.git
 	branch = refs/heads/master
 [submodule "python-drmaa"]
-	path = feedstocks/python-drmaa
+	path = feedstocks/drmaa
 	url = https://github.com/conda-forge/python-drmaa-feedstock.git
 	branch = refs/heads/master
 [submodule "pickleshare"]


### PR DESCRIPTION
The rename is occurring to match the package name in `defaults`.

xref: https://github.com/conda-forge/drmaa-feedstock/issues/3