### PR TITLE
Drop `python-drmaa` from `.gitmodules`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1190,10 +1190,6 @@
 	path = feedstocks/ptyprocess
 	url = https://github.com/conda-forge/ptyprocess-feedstock.git
 	branch = refs/heads/master
-[submodule "python-drmaa"]
-	path = feedstocks/drmaa
-	url = https://github.com/conda-forge/python-drmaa-feedstock.git
-	branch = refs/heads/master
 [submodule "pickleshare"]
 	path = feedstocks/pickleshare
 	url = https://github.com/conda-forge/pickleshare-feedstock.git


### PR DESCRIPTION
Has since been renamed to `drmaa` to match `defaults`. So drop the no longer accurate `python-drmaa` submodule.

xref: https://github.com/conda-forge/drmaa-feedstock/issues/3
xref: https://github.com/conda-forge/feedstocks/pull/36