### PR TITLE
Remove py-graphviz

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20478,10 +20478,6 @@
 	url = https://github.com/conda-forge/gwpy-feedstock.git
 	path = feedstocks/gwpy
 	branch = refs/heads/master
-[submodule "py-graphviz"]
-	url = https://github.com/conda-forge/py-graphviz-feedstock.git
-	path = feedstocks/py-graphviz
-	branch = refs/heads/master
 [submodule "pyqode.core"]
 	url = https://github.com/conda-forge/pyqode.core-feedstock.git
 	path = feedstocks/pyqode.core


### PR DESCRIPTION
This was an accidental duplicate of `python-graphviz`. So we removed the feedstock. This cleans it from the feedstock submodules.

xref: https://github.com/conda-forge/feedstocks/pull/51
xref: https://github.com/conda-forge/staged-recipes/pull/6534#issuecomment-414354224