### PR TITLE
Remove py-graphviz

### DIFF
--- a/index.html
+++ b/index.html
@@ -14580,12 +14580,6 @@
                     </li>
 
                     <li class="list-group-item">
-                        <a href="https://github.com/conda-forge/py-graphviz-feedstock">
-                            py-graphviz
-                        </a>
-                    </li>
-
-                    <li class="list-group-item">
                         <a href="https://github.com/conda-forge/py-lz4framed-feedstock">
                             py-lz4framed
                         </a>


### PR DESCRIPTION
This was an accidental duplicate of `python-graphviz`. So we removed the feedstock. This cleans it from the feedstock webpage listing.

xref: https://github.com/conda-forge/feedstocks/pull/50
xref: https://github.com/conda-forge/staged-recipes/pull/6534#issuecomment-414354224