### PR TITLE
Remove java-org.apache.arrow.arrow-jdbc-with-dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34990,10 +34990,6 @@
 	url = https://github.com/conda-forge/sccache-feedstock.git
 	path = feedstocks/sccache
 	branch = refs/heads/master
-[submodule "java-org.apache.arrow.arrow-jdbc-with-dependencies"]
-	url = https://github.com/conda-forge/java-org.apache.arrow.arrow-jdbc-with-dependencies-feedstock.git
-	path = feedstocks/java-org.apache.arrow.arrow-jdbc-with-dependencies
-	branch = refs/heads/master
 [submodule "pynucos"]
 	url = https://github.com/conda-forge/pynucos-feedstock.git
 	path = feedstocks/pynucos


### PR DESCRIPTION
This feedstock has been completely deleted. So drop it from the submodules as it does not exist any more.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
