### PR TITLE
remove deleted nss-cos7-aarch64 feedstock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37282,10 +37282,6 @@
 	url = https://github.com/conda-forge/java-1.7.0-openjdk-cos7-aarch64-feedstock.git
 	path = feedstocks/java-1.7.0-openjdk-cos7-aarch64
 	branch = refs/heads/master
-[submodule "nss-cos7-aarch64"]
-	url = https://github.com/conda-forge/nss-cos7-aarch64-feedstock.git
-	path = feedstocks/nss-cos7-aarch64
-	branch = refs/heads/master
 [submodule "nss-softokn-cos7-aarch64"]
 	url = https://github.com/conda-forge/nss-softokn-cos7-aarch64-feedstock.git
 	path = feedstocks/nss-softokn-cos7-aarch64


### PR DESCRIPTION
I guess this is the accidentally removed CDT feedstock @beckermr mentioned.