### PR TITLE
Remove `mkdocstrings-python-legacy`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62546,10 +62546,6 @@
 	url = https://github.com/conda-forge/ovh-feedstock.git
 	path = feedstocks/ovh
 	branch = refs/heads/main
-[submodule "mkdocstrings-python-legacy"]
-	url = https://github.com/conda-forge/mkdocstrings-python-legacy-feedstock.git
-	path = feedstocks/mkdocstrings-python-legacy
-	branch = refs/heads/main
 [submodule "morph"]
 	url = https://github.com/conda-forge/morph-feedstock.git
 	path = feedstocks/morph


### PR DESCRIPTION
This was created due to a temporary commit used to try and fix the CircleCI registration issues encounted in staged-recipes. However the commit no longer exists as the repo was removed after adding that commit. In any event leaving this in here atm causes issues cloning the repo, so remove it. Once the feedstock is converted this will be readded anyways.

xref: https://github.com/conda-forge/staged-recipes/issues/18287